### PR TITLE
Fix variant links

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ The sketchy description how *VidLoader* works is represented in the next diagram
 
 ## Requirements
 
-- iOS 12.0+  
-- A device, <span style="color:red">AVAssetDownloadURLSession doesn't work on the simulator</span>
-
+```diff
++ iOS 12.0+
+@@ AVAssetDownloadURLSession doesn't work on the simulator, a real device is required @@
+```
 ## Installation
 
 ### CocoaPods

--- a/VidLoader/VidLoader.xcodeproj/project.pbxproj
+++ b/VidLoader/VidLoader.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		0B7C1CA423A1426500F9E69A /* MockFileHandleable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1CA323A1426500F9E69A /* MockFileHandleable.swift */; };
 		0B7C1CA623A1432100F9E69A /* MockAVAssetResourceLoaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1CA523A1432100F9E69A /* MockAVAssetResourceLoaderDelegate.swift */; };
 		0B7C1CA823A1438200F9E69A /* MockObserversHandleable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1CA723A1438200F9E69A /* MockObserversHandleable.swift */; };
+		0B9A16E3249D237D00E9F837 /* StreamResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9A16E2249D237D00E9F837 /* StreamResourceTests.swift */; };
 		0B9AD2AC23A0200300158D50 /* M3U8PlaylistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AD2AB23A0200300158D50 /* M3U8PlaylistTests.swift */; };
 		0B9AD2B423A0317600158D50 /* DataExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AD2B323A0317600158D50 /* DataExtensionsTests.swift */; };
 		0B9AD2B623A0335700158D50 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9AD2B523A0335700158D50 /* StringExtensionsTests.swift */; };
@@ -144,6 +145,7 @@
 		0B7C1CA323A1426500F9E69A /* MockFileHandleable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileHandleable.swift; sourceTree = "<group>"; };
 		0B7C1CA523A1432100F9E69A /* MockAVAssetResourceLoaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAVAssetResourceLoaderDelegate.swift; sourceTree = "<group>"; };
 		0B7C1CA723A1438200F9E69A /* MockObserversHandleable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockObserversHandleable.swift; sourceTree = "<group>"; };
+		0B9A16E2249D237D00E9F837 /* StreamResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamResourceTests.swift; sourceTree = "<group>"; };
 		0B9AD2AB23A0200300158D50 /* M3U8PlaylistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = M3U8PlaylistTests.swift; sourceTree = "<group>"; };
 		0B9AD2B323A0317600158D50 /* DataExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensionsTests.swift; sourceTree = "<group>"; };
 		0B9AD2B523A0335700158D50 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
@@ -369,6 +371,7 @@
 			children = (
 				0B9AD2BA23A03C0B00158D50 /* ItemInformationTests.swift */,
 				0B9AD2BC23A043D800158D50 /* DownloadStateTests.swift */,
+				0B9A16E2249D237D00E9F837 /* StreamResourceTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -731,6 +734,7 @@
 				0B519864239AF06300AEC201 /* FunCheck.swift in Sources */,
 				0B354AFC2396953C009CE690 /* MockRequestable.swift in Sources */,
 				0BEC4B16239EE11100AA39D9 /* MockAVAssetDownloadURLSession.swift in Sources */,
+				0B9A16E3249D237D00E9F837 /* StreamResourceTests.swift in Sources */,
 				0B354B012396953C009CE690 /* DataExtensions.swift in Sources */,
 				0BEC4B18239EE20F00AA39D9 /* MockAVAssetDownloadTask.swift in Sources */,
 				0B7C1C9E23A13F6C00F9E69A /* MockPlaylistLoadable.swift in Sources */,

--- a/VidLoader/VidLoader/Sources/Classes/M3U8Parser/M3U8Playlist.swift
+++ b/VidLoader/VidLoader/Sources/Classes/M3U8Parser/M3U8Playlist.swift
@@ -37,7 +37,6 @@ final class M3U8Playlist: PlaylistParser {
             return completion(.failure(.dataConversion))
         }
         let newResponse = replaceRelativeChunks(response: response, with: baseURL)
-        print(newResponse)
         replacePaths(response: newResponse, with: baseURL, completion: { result in
             switch result {
             case .success: completion(result)
@@ -55,7 +54,6 @@ final class M3U8Playlist: PlaylistParser {
     private func replacePaths(response: String,
                               with baseURL: URL,
                               completion: @escaping (Result<Data, M3U8Error>) -> Void) {
-        print(response)
         let keysURLs = response.matches(for: keyRegex).compactMap { generateURL(keyPath: $0, baseURL: baseURL) }
         guard !keysURLs.isEmpty else {
             return completion(.failure(.keyURLMissing))

--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/ResourceLoader.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/ResourceLoader.swift
@@ -45,7 +45,6 @@ final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
                                           expectedContentLength: persistentKey.count,
                                           textEncodingName: nil)
             loadingRequest.setup(response: keyResponse, data: persistentKey)
-            print("#### keyDidLoad")
             observer.keyDidLoad()
         } else {
             switch streamResource?.fileType {

--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/ResourceLoader.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/ResourceLoader.swift
@@ -16,9 +16,8 @@ final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
     private let observer: ResourceLoaderObserver
     private let masterParser: MasterParser
     private let playlistParser: PlaylistParser
-    private let streamResource: StreamResource
+    private var streamResource: StreamResource?
     private let requestable: Requestable
-    private var didProvideFirstResponse = false
     private let schemeHandler: SchemeHandleable
     
     init(observer: ResourceLoaderObserver,
@@ -46,14 +45,16 @@ final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
                                           expectedContentLength: persistentKey.count,
                                           textEncodingName: nil)
             loadingRequest.setup(response: keyResponse, data: persistentKey)
+            print("#### keyDidLoad")
             observer.keyDidLoad()
         } else {
-            if !didProvideFirstResponse {
-                adjustMasterFile(streamResource: streamResource, loadingRequest: loadingRequest)
-            } else {
+            switch streamResource?.fileType {
+            case .master:
+                adjustMasterFile(streamResource: streamResource!, loadingRequest: loadingRequest)
+                streamResource = nil
+            case .none, .variant:
                 performPlaylistRequest(with: url, loadingRequest: loadingRequest)
             }
-            didProvideFirstResponse = true
         }
         
         return true

--- a/VidLoader/VidLoader/Sources/Models/StreamResource.swift
+++ b/VidLoader/VidLoader/Sources/Models/StreamResource.swift
@@ -9,6 +9,22 @@
 import Foundation
 
 struct StreamResource: Equatable {
+    enum FileType {
+        case master
+        case variant
+    }
     let response: HTTPURLResponse
     let data: Data
+    let fileType: FileType
+    
+    init(response: HTTPURLResponse, data: Data) {
+        self.response = response
+        self.data = data
+        switch variantChunkKey.data {
+        case let .some(chunkKey):
+            fileType = data.range(of: chunkKey) == nil ? .master : .variant
+        case .none:
+            fileType = .master
+        }
+    }
 }

--- a/VidLoader/VidLoaderTests/Tests/Classes/M3U8Parser/M3U8PlaylistTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/M3U8Parser/M3U8PlaylistTests.swift
@@ -52,12 +52,12 @@ final class M3U8PlaylistTests: XCTestCase {
         XCTAssertEqual(expectedResult, finalResult)
     }
     
-    func test_AdjustPlaylistSchemes_KeyDownloadFailed_AdjustWillFail() {
+    func test_AdjustPlaylistSchemes_KeyDownloadFailed_AdjustWillReturnSameResponse() {
         // GIVEN
         let baseURL = URL.mock(stringURL: "https://base_url")
         let givenString = "#EXT-X-KEYURI=\"https://random_url\""
         let givenError: DownloadError = .unknown
-        let expectedResult: Result<Data, M3U8Error> = .failure(.custom(.init(error: givenError)))
+        let expectedResult: Result<Data, M3U8Error> = .success(givenString.data!)
         var finalResult: Result<Data, M3U8Error>?
         requestable.dataTaskStub = .mock()
         requestable.completionHandlerStub = (nil, nil, givenError)
@@ -101,12 +101,14 @@ final class M3U8PlaylistTests: XCTestCase {
             #EXT-X-KEY:random_staff URI=\"relative_random_path\"#EXTINF:12.012,1920_00001.ts
             #EXTINF:12.012,\n1920_00002.ts
             #EXTINF:12.012,/1920_00003.ts\n#EXTINF:12.012,../1920_00004.ts#EXT-X-ENDLIST
+            #EXT-X-KEY:random_staff URI=\"http://unique_relative_path\"#EXTINF:12.012,1920_00001.ts
         """
         let base64String = "Ym9uZF9qYW1lc19ib25k"
         let expectedResponse = """
             #EXT-X-KEY:random_staff URI=\"\(SchemeType.key.rawValue):\(base64String)\"#EXTINF:12.012,\(baseURLString)/1920_00001.ts
             #EXTINF:12.012,\n\(baseURLString)/1920_00002.ts
             #EXTINF:12.012,\(baseURLString)/1920_00003.ts\n#EXTINF:12.012,\(baseURLString)/../1920_00004.ts#EXT-X-ENDLIST
+            #EXT-X-KEY:random_staff URI=\"\(SchemeType.key.rawValue):\(base64String)\"#EXTINF:12.012,\(baseURLString)/1920_00001.ts
         """
         let expectedResult: Result<Data, M3U8Error> = .success(.mock(string: expectedResponse))
         var finalResult: Result<Data, M3U8Error>?

--- a/VidLoader/VidLoaderTests/Tests/Models/StreamResourceTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Models/StreamResourceTests.swift
@@ -1,0 +1,43 @@
+//
+//  StreamResourceTests.swift
+//  VidLoaderTests
+//
+//  Created by Petre on 6/19/20.
+//  Copyright © 2020 Petre. All rights reserved.
+//
+
+import XCTest
+@testable import VidLoader
+
+final class StreamResourceTests: XCTestCase {
+    
+    func test_GenerateStreamResource_WithoutChunkKey_FileTypeMaster() {
+        // GIVEN
+        let givenData = "no_chunk_key_inside".data!
+        let givenResponse = HTTPURLResponse.mock()
+        let expectedFileType: StreamResource.FileType = .master
+        
+        // WHEN
+        let resultStream = StreamResource(response: givenResponse, data: givenData)
+        
+        // THEN
+        XCTAssertEqual(givenData, resultStream.data)
+        XCTAssertEqual(givenResponse, resultStream.response)
+        XCTAssertEqual(expectedFileType, resultStream.fileType)
+    }
+    
+    func test_GenerateStreamResource_WithChunkKey_FileTypeVariant() {
+        // GIVEN
+        let givenData = "no_chunk_key_inside\(variantChunkKey)".data!
+        let givenResponse = HTTPURLResponse.mock()
+        let expectedFileType: StreamResource.FileType = .variant
+        
+        // WHEN
+        let resultStream = StreamResource(response: givenResponse, data: givenData)
+        
+        // THEN
+        XCTAssertEqual(givenData, resultStream.data)
+        XCTAssertEqual(givenResponse, resultStream.response)
+        XCTAssertEqual(expectedFileType, resultStream.fileType)
+    }
+}

--- a/VidLoaderExample/VidLoaderExample/VideoList/VideoListDataProvider.swift
+++ b/VidLoaderExample/VidLoaderExample/VideoList/VideoListDataProvider.swift
@@ -90,7 +90,7 @@ final class VideoListDataProvider: VideoListDataProviding {
                                             url: url,
                                             title: data.title,
                                             artworkData: UIImage(named: data.imageName)?.jpegData(compressionQuality: 1),
-                                            minRequiredBitrate: 2081059)
+                                            minRequiredBitrate: 1)
         vidLoaderHandler.loader.download(downloadValues)
     }
     


### PR DESCRIPTION
Fix issue #6
Links types described below have been tested:
```diff
+ master playlist link that has variants without the encryption key
+ master playlist link that has variants with an encryption key
+ master playlist link that has variants with relative paths
+ variant link with multiple encryptions key
```