### PR TITLE
Update item state before the session will do it

### DIFF
--- a/VidLoader/VidLoader/Sources/VidLoader.swift
+++ b/VidLoader/VidLoader/Sources/VidLoader.swift
@@ -246,9 +246,12 @@ public final class VidLoader: VidLoadable {
             let url = URL(string: item.mediaLink) else { return }
         switch schemeHandler.urlAsset(with: url) {
         case .success(let urlAsset):
-            startTask(urlAsset: urlAsset, streamResource: streamResource.1, item: item)
+            startTask(urlAsset: urlAsset,
+                      streamResource: streamResource.1,
+                      item: item |> ItemInformation._state .~ .running(0))
         case .failure(let error):
-            handle(event: .failed(error: .init(error: error)), activeItem: item)
+            handle(event: .failed(error: .init(error: error)),
+                   activeItem: item)
         }
     }
 

--- a/VidLoader/VidLoaderTests/Tests/VidLoaderTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/VidLoaderTests.swift
@@ -428,6 +428,7 @@ final class VidLoaderTests: XCTestCase {
         XCTAssertEqual(observersHandler.fireFuncCheck.arguments?.1, expectedItem)
         XCTAssertTrue(givenTask.resumeFunc.wasCalled())
         XCTAssertEqual(resourcesDelegatesHandler.addFuncCheck.arguments?.0, givenIdentifier)
+        XCTAssertEqual(session.addNewTaskFuncCheck.arguments?.1, givenItem |> ItemInformation._state .~ .running(0))
     }
 
     func test_SessionWasSet_PausedWasCalled_SessionWillPauseTask() {


### PR DESCRIPTION
**Description:** The download state is updated by session and there is a small window when `maxConcurrentDownloads` will not be taken into consideration. 
**Solution:** Update item state to running right after the task was created.

Fixes #26