### PR TITLE
Added http headers support to allow m3u8 and keys download

### DIFF
--- a/VidLoader/VidLoader/Sources/Models/DownloadValues.swift
+++ b/VidLoader/VidLoader/Sources/Models/DownloadValues.swift
@@ -12,6 +12,7 @@ public struct DownloadValues {
     let title: String
     let artworkData: Data?
     let minRequiredBitrate: Int?
+    let headers: [String: String]?
     
     /// - Parameters:
     ///   - identifier: Item's unique identifier
@@ -19,11 +20,13 @@ public struct DownloadValues {
     ///   - title: Item's title that will be presented in the phone settings
     ///   - artworkData: Item's optional thumbnail that will be presented in the phone settings
     ///   - minRequiredBitrate: Lowest media bitrate to be used that is greater than or equal to this value, bits per second. If it's nil, then the highest media bitrate will be selected by default.
-    public init(identifier: String, url: URL, title: String, artworkData: Data? = nil, minRequiredBitrate: Int? = nil) {
+    ///   - headers: HTTPHeader to be used when headers is necessary to download m3u8 or key files
+    public init(identifier: String, url: URL, title: String, artworkData: Data? = nil, minRequiredBitrate: Int? = nil, headers: [String: String]? = nil) {
         self.identifier = identifier
         self.url = url
         self.title = title
         self.artworkData = artworkData
         self.minRequiredBitrate = minRequiredBitrate
+        self.headers = headers
     }
 }

--- a/VidLoader/VidLoader/Sources/Models/ItemInformation.swift
+++ b/VidLoader/VidLoader/Sources/Models/ItemInformation.swift
@@ -30,11 +30,14 @@ public struct ItemInformation: Codable, Equatable {
     /// Tthe lowest media bitrate to be used that is greater than or equal to this value
     /// Value should be used as NSNumber in bits per second. If no suitable media bitrate is found, the highest media bitrate will be selected
     let minRequiredBitrate: Int?
+    ///HTTPHeader to be used when headers is necessary to download m3u8 or key files
+    let headers: [String: String]?
 
     init(identifier: String, title: String?, path: String? = nil,
          mediaLink: String = "", progress: Double = 0,
          state: DownloadState, downloadedBytes: Int = 0,
-         artworkData: Data?, minRequiredBitrate: Int?) {
+         artworkData: Data?, minRequiredBitrate: Int?,
+         headers: [String: String]? = nil) {
         self.identifier = identifier
         self.title = title
         self.path = path
@@ -44,6 +47,7 @@ public struct ItemInformation: Codable, Equatable {
         self.downloadedBytes = downloadedBytes
         self.artworkData = artworkData
         self.minRequiredBitrate = minRequiredBitrate
+        self.headers = headers
     }
 
     public var location: URL? {
@@ -105,7 +109,8 @@ extension ItemInformation {
         set: { ItemInformation(identifier: $1.identifier, title: $1.title, path: $1.path,
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $0, downloadedBytes: $1.downloadedBytes,
-                               artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate) }
+                               artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
+                               headers: $1.headers) }
     )
 
     static let _path = Lens<ItemInformation, String?>(
@@ -113,7 +118,8 @@ extension ItemInformation {
         set: { ItemInformation(identifier: $1.identifier, title: $1.title, path: $0,
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $1.state, downloadedBytes: $1.downloadedBytes,
-                               artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate) }
+                               artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
+                               headers: $1.headers) }
     )
 
     static let _progress = Lens<ItemInformation, Double>(
@@ -121,7 +127,8 @@ extension ItemInformation {
         set: { ItemInformation(identifier: $1.identifier, title: $1.title, path: $1.path,
                                mediaLink: $1.mediaLink, progress: $0,
                                state: $1.state, downloadedBytes: $1.downloadedBytes,
-                               artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate) }
+                               artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
+                               headers: $1.headers) }
     )
 
     static let _downloadedBytes = Lens<ItemInformation, Int>(
@@ -129,6 +136,7 @@ extension ItemInformation {
         set: { ItemInformation(identifier: $1.identifier, title: $1.title, path: $1.path,
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $1.state, downloadedBytes: $0,
-                               artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate) }
+                               artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
+                               headers: $1.headers) }
     )
 }

--- a/VidLoader/VidLoader/Sources/VidLoader.swift
+++ b/VidLoader/VidLoader/Sources/VidLoader.swift
@@ -124,7 +124,8 @@ public final class VidLoader: VidLoadable {
                                    mediaLink: url.absoluteString,
                                    state: .unknown,
                                    artworkData: values.artworkData,
-                                   minRequiredBitrate: values.minRequiredBitrate)
+                                   minRequiredBitrate: values.minRequiredBitrate,
+                                   headers: values.headers)
         activeItems[identifier] = item
         handle(event: .prefetching, activeItem: item)
         session.task(identifier: identifier, completion: { [weak self] task in
@@ -236,7 +237,7 @@ public final class VidLoader: VidLoadable {
                 self?.handle(event: .failed(error: .init(error: error)), activeItem: item)
             }
         }
-        playlistLoader.load(identifier: item.identifier, at: url, completion: handleResult)
+        playlistLoader.load(identifier: item.identifier, at: url, headers: item.headers, completion: handleResult)
     }
 
     private func startNewTaskIfNeeded() {
@@ -274,7 +275,7 @@ public final class VidLoader: VidLoadable {
             self?.handle(event: .failed(error: .init(error: error)), activeItem: item)
         }
         let observer = ResourceLoaderObserver(taskDidFail: taskDidFail, keyDidLoad: keyDidLoad)
-        let resourceLoader = ResourceLoader(observer: observer, streamResource: streamResource)
+        let resourceLoader = ResourceLoader(observer: observer, streamResource: streamResource, headers: item.headers)
         task.urlAsset.resourceLoader.setDelegate(resourceLoader, queue: resourceLoader.queue)
         task.urlAsset.resourceLoader.preloadsEligibleContentKeys = true
         resourcesDelegatesHandler.add(identifier: item.identifier, loader: resourceLoader)


### PR DESCRIPTION
A created this HTTP header implementation to allow downloading m3u8 and keys from Akamai.

For Akamai, I need to add User-Agent with "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1" value, otherwise the request won't work.

``` Swift
func startDownload(with data: VideoData) {
        guard let url = URL(string: data.stringURL) else { return }
        let downloadValues = DownloadValues(identifier: data.identifier,
                                            url: url,
                                            title: data.title,
                                            artworkData: UIImage(named: data.imageName)?.jpegData(compressionQuality: 1),
                                            minRequiredBitrate: 1,
                                            headers: ["User-Agent" : "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1"])
        vidLoaderHandler.loader.download(downloadValues)
    }
```