### PR TITLE
ISSUE-41 Fix iOS 16 resource loader

### DIFF
--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/ResourceLoader.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/ResourceLoader.swift
@@ -52,8 +52,8 @@ final class ResourceLoader: NSObject, AVAssetResourceLoaderDelegate {
         } else {
             switch streamResource?.fileType {
             case .master:
-                self.adjustMasterFile(streamResource: self.streamResource!, loadingRequest: loadingRequest)
-                self.streamResource = nil
+                adjustMasterFile(streamResource: streamResource!, loadingRequest: loadingRequest)
+                streamResource = nil
                 // For m3u8 master file shouldWaitForLoadingOfRequestedResource in iOS 16 behaves differently,
                 // adjustMasterFile is a sync operation without having any request in place.
                 // Session is failling with CoreMediaErrorDomain Code=-12640, to avoid this issue we either return false in this case

--- a/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/ResourceLoaderTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/ResourceLoaderTests.swift
@@ -82,7 +82,11 @@ final class ResourceLoaderTests: XCTestCase {
                                                               shouldWaitForLoadingOfRequestedResource: loadingRequest)
         
         // THEN
-        XCTAssertTrue(requestShouldWait)
+        if #available(iOS 16, *) {
+            XCTAssertFalse(requestShouldWait)
+        } else {
+            XCTAssertTrue(requestShouldWait)
+        }
         XCTAssertNil(loadingRequest.setupFuncDidCall)
         XCTAssertEqual(expectedError, resultError)
         XCTAssertFalse(keyDidLoad)
@@ -108,7 +112,11 @@ final class ResourceLoaderTests: XCTestCase {
                                                               shouldWaitForLoadingOfRequestedResource: loadingRequest)
         
         // THEN
-        XCTAssertTrue(requestShouldWait)
+        if #available(iOS 16, *) {
+            XCTAssertFalse(requestShouldWait)
+        } else {
+            XCTAssertTrue(requestShouldWait)
+        }
         XCTAssertEqual(loadingRequest.setupFuncDidCall, true)
         XCTAssertNil(resultError)
         XCTAssertFalse(keyDidLoad)


### PR DESCRIPTION
For m3u8 master file shouldWaitForLoadingOfRequestedResource in iOS 16 behaves differently, adjustMasterFile is a sync operation without having any request in place.
Session is failling with CoreMediaErrorDomain Code=-12640, to avoid this issue we either return false in this case session doesn't wait for the results that are already provided OR we add an artificial delay for adjustMasterFile that can have edge cases in case session still needs more time to handle AVAssetResourceLoadingRequest finishLoading operation it will fail.