### PR TITLE
Fix crash with content allowed type

### DIFF
--- a/VidLoader/VidLoader.xcodeproj/project.pbxproj
+++ b/VidLoader/VidLoader.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0B1495B3239FEF2D007ED700 /* AVURLAssetExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1495B2239FEF2D007ED700 /* AVURLAssetExtensions.swift */; };
 		0B1495B523A002C1007ED700 /* CMTimeRangeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1495B423A002C1007ED700 /* CMTimeRangeExtensions.swift */; };
 		0B1495BC23A0104D007ED700 /* M3U8MasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1495BB23A0104D007ED700 /* M3U8MasterTests.swift */; };
+		0B1DA59628E04260005534F0 /* AVAssetResourceLoadingContentInformationRequestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1DA59528E04260005534F0 /* AVAssetResourceLoadingContentInformationRequestExtensions.swift */; };
 		0B354AFB2396953C009CE690 /* CustomDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B354AED2396953C009CE690 /* CustomDataTask.swift */; };
 		0B354AFC2396953C009CE690 /* MockRequestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B354AEE2396953C009CE690 /* MockRequestable.swift */; };
 		0B354AFD2396953C009CE690 /* PlaylistLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B354AF12396953C009CE690 /* PlaylistLoaderTests.swift */; };
@@ -117,6 +118,7 @@
 		0B1495B2239FEF2D007ED700 /* AVURLAssetExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetExtensions.swift; sourceTree = "<group>"; };
 		0B1495B423A002C1007ED700 /* CMTimeRangeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMTimeRangeExtensions.swift; sourceTree = "<group>"; };
 		0B1495BB23A0104D007ED700 /* M3U8MasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = M3U8MasterTests.swift; sourceTree = "<group>"; };
+		0B1DA59528E04260005534F0 /* AVAssetResourceLoadingContentInformationRequestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAssetResourceLoadingContentInformationRequestExtensions.swift; sourceTree = "<group>"; };
 		0B354AED2396953C009CE690 /* CustomDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomDataTask.swift; sourceTree = "<group>"; };
 		0B354AEE2396953C009CE690 /* MockRequestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRequestable.swift; sourceTree = "<group>"; };
 		0B354AF12396953C009CE690 /* PlaylistLoaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistLoaderTests.swift; sourceTree = "<group>"; };
@@ -326,6 +328,7 @@
 				0B1495B2239FEF2D007ED700 /* AVURLAssetExtensions.swift */,
 				0B1495B423A002C1007ED700 /* CMTimeRangeExtensions.swift */,
 				0B07F6A8249BF00600F99458 /* DownloadValuesExtensions.swift */,
+				0B1DA59528E04260005534F0 /* AVAssetResourceLoadingContentInformationRequestExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -737,6 +740,7 @@
 				0B519864239AF06300AEC201 /* FunCheck.swift in Sources */,
 				0BE731B5282C5D9A00D5C1AC /* SelectorExtensions.swift in Sources */,
 				0B354AFC2396953C009CE690 /* MockRequestable.swift in Sources */,
+				0B1DA59628E04260005534F0 /* AVAssetResourceLoadingContentInformationRequestExtensions.swift in Sources */,
 				0BEC4B16239EE11100AA39D9 /* MockAVAssetDownloadURLSession.swift in Sources */,
 				0B9A16E3249D237D00E9F837 /* StreamResourceTests.swift in Sources */,
 				0B354B012396953C009CE690 /* DataExtensions.swift in Sources */,

--- a/VidLoader/VidLoader/Sources/Extensions/AVAssetResourceLoadingRequestExtensions.swift
+++ b/VidLoader/VidLoader/Sources/Extensions/AVAssetResourceLoadingRequestExtensions.swift
@@ -10,10 +10,20 @@ import AVFoundation
 
 extension AVAssetResourceLoadingRequest {
     @objc public func setup(response: URLResponse, data: Data) {
-        contentInformationRequest?.contentType = response.mimeType
+        contentInformationRequest?.contentType = response.mimeType |> generateAllowedContentType
         contentInformationRequest?.isByteRangeAccessSupported = true
         contentInformationRequest?.contentLength = response.expectedContentLength
         dataRequest?.respond(with: data)
         finishLoading()
+    }
+    
+    private func generateAllowedContentType(mimeType: String?) -> String? {
+        guard let allowedTypes = contentInformationRequest?.allowedContentTypes else {
+            return mimeType
+        }
+        guard let contentType = allowedTypes.first(where: { $0 == mimeType }) else {
+            return nil
+        }
+        return contentType
     }
 }

--- a/VidLoader/VidLoaderTests/Extensions/AVAssetResourceLoadingContentInformationRequestExtensions.swift
+++ b/VidLoader/VidLoaderTests/Extensions/AVAssetResourceLoadingContentInformationRequestExtensions.swift
@@ -1,0 +1,33 @@
+//
+//  AVAssetResourceLoadingContentInformationRequestExtensions.swift
+//  VidLoaderTests
+//
+//  Created by Petre Plotnic on 25.09.22.
+//  Copyright © 2022 Petre. All rights reserved.
+//
+
+import AVFoundation
+
+extension AVAssetResourceLoadingContentInformationRequest {
+    
+    static func mock(loadingRequest: AVAssetResourceLoadingRequest,
+                     allowedContentTypes: NSArray?) -> AVAssetResourceLoadingContentInformationRequest {
+        let finalSelector = Selector(("initWithLoadingRequest:allowedContentTypes:"))
+        let initialSelector = #selector(NSObject.init)
+        let initialInit = class_getInstanceMethod(self, initialSelector)!
+        let finalInit = class_getInstanceMethod(self, finalSelector)!
+        let finalInitImpl = method_getImplementation(finalInit)
+        typealias FinalInit = @convention(c) (AnyObject, Selector, AVAssetResourceLoadingRequest, NSArray?) -> AVAssetResourceLoadingContentInformationRequest
+        typealias InitialInit = @convention(block) (AnyObject, Selector) -> AVAssetResourceLoadingContentInformationRequest
+        let finalBlockInit = unsafeBitCast(finalInitImpl, to: FinalInit.self)
+        var contentInformationRequest: AVAssetResourceLoadingContentInformationRequest!
+        let newBlock: InitialInit = { obj, sel in
+            contentInformationRequest = finalBlockInit(obj, finalSelector, loadingRequest, allowedContentTypes)
+            return contentInformationRequest
+        }
+        method_setImplementation(initialInit, imp_implementationWithBlock(newBlock))
+        perform(Selector.defaultNew)
+        
+        return contentInformationRequest
+    }
+}

--- a/VidLoader/VidLoaderTests/Extensions/AVAssetResourceLoadingRequestExtensions.swift
+++ b/VidLoader/VidLoaderTests/Extensions/AVAssetResourceLoadingRequestExtensions.swift
@@ -32,11 +32,44 @@ extension AVAssetResourceLoadingRequest {
     @objc func mockSetup(response: URLResponse, data: Data) {
         setupFuncDidCall = true
     }
+    
+    static var contentInformationRequestAssociationKey: NSInteger = 1
+    var contentInformationRequestStub: AVAssetResourceLoadingContentInformationRequest? {
+        get {
+            let instance = objc_getAssociatedObject(self, &AVAssetResourceLoadingRequest.contentInformationRequestAssociationKey) as? AVAssetResourceLoadingContentInformationRequest
+            return instance
+        }
+        set(newValue) {
+            objc_setAssociatedObject(self, &AVAssetResourceLoadingRequest.contentInformationRequestAssociationKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+    
+    @objc var mockContentInformationRequest: AVAssetResourceLoadingContentInformationRequest? {
+        return contentInformationRequestStub
+    }
+    
+    static func mockWithCustomContentInfoRequest(with resourceLoader: AVAssetResourceLoader = .mock(),
+                                                 requestInfo: NSDictionary = mockRequestInfo(),
+                                                 requestID: Int = 1) -> AVAssetResourceLoadingRequest {
+        return create(with: resourceLoader,
+                      requestInfo: requestInfo,
+                      requestID: requestID,
+                      swizzleAction: { swizzle(className: self, original: #selector(getter: contentInformationRequest), new: #selector(getter: mockContentInformationRequest)) })
+    }
+    
+    static func mockWithCustomSetup(with resourceLoader: AVAssetResourceLoader = .mock(),
+                                    requestInfo: NSDictionary = mockRequestInfo(),
+                                    requestID: Int = 1) -> AVAssetResourceLoadingRequest {
+        return create(with: resourceLoader,
+                      requestInfo: requestInfo,
+                      requestID: requestID,
+                      swizzleAction: { swizzle(className: self, original: #selector(setup(response:data:)), new: #selector(mockSetup(response:data:))) })
+    }
 
-    static func mock(with resourceLoader: AVAssetResourceLoader = .mock(),
-                     requestInfo: NSDictionary = mockRequestInfo(),
-                     requestID: Int = 1,
-                     shouldSwizzle: Bool = true) -> AVAssetResourceLoadingRequest {
+    static private func create(with resourceLoader: AVAssetResourceLoader = .mock(),
+                               requestInfo: NSDictionary = mockRequestInfo(),
+                               requestID: Int = 1,
+                               swizzleAction: (() -> Void)?) -> AVAssetResourceLoadingRequest {
         let finalSelector = Selector(("initWithResourceLoader:requestInfo:requestID:"))
         let initialSelector = #selector(NSObject.init)
         let initialInit = class_getInstanceMethod(self, initialSelector)!
@@ -48,9 +81,7 @@ extension AVAssetResourceLoadingRequest {
         var request: AVAssetResourceLoadingRequest!
         let newBlock: InitialInit = { obj, sel in
             request = finalBlockInit(obj, finalSelector, resourceLoader, requestInfo, requestID)
-            if shouldSwizzle {
-                swizzle(className: self, original: #selector(setup(response:data:)), new: #selector(mockSetup(response:data:)))
-            }
+            swizzleAction?()
             return request
         }
         method_setImplementation(initialInit, imp_implementationWithBlock(newBlock))

--- a/VidLoader/VidLoaderTests/Mocks/MockAVAssetDownloadURLSession.swift
+++ b/VidLoader/VidLoaderTests/Mocks/MockAVAssetDownloadURLSession.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Foundation
 
 extension MockAVAssetDownloadURLSession {
-    static func mock(shouldSwizzle: Bool = true) -> MockAVAssetDownloadURLSession {
+    static func mock() -> MockAVAssetDownloadURLSession {
         let finalSelector = Selector.defaultInit
         let initialSelector = #selector(NSObject.init)
         let initialInit = class_getInstanceMethod(self, initialSelector)!

--- a/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/KeyLoaderTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/KeyLoaderTests.swift
@@ -23,7 +23,7 @@ final class KeyLoaderTests: XCTestCase {
         // GIVEN
         let expectedURL = URL.mock()
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: expectedURL)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(requestInfo: requestInfo)
         schemeHandler.persistentKeyStub = nil
         keyLoader = KeyLoader(schemeHandler: schemeHandler)
         
@@ -41,7 +41,7 @@ final class KeyLoaderTests: XCTestCase {
         // GIVEN
         let expectedURL = URL.mock()
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: expectedURL)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(requestInfo: requestInfo)
         let mockData = Data.mock(string: "mock_key_data")
         schemeHandler.persistentKeyStub = mockData
         keyLoader = KeyLoader(schemeHandler: schemeHandler)

--- a/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/ResourceLoaderTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/ResourceLoaderTests.swift
@@ -49,7 +49,7 @@ final class ResourceLoaderTests: XCTestCase {
         let url = URL.mock()
         let avResourceLoader = AVAssetResourceLoader.mock(url: url)
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: url)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(with: avResourceLoader, requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(with: avResourceLoader, requestInfo: requestInfo)
         
         // WHEN
         let requestShouldWait = resourceLoader.resourceLoader(avResourceLoader,
@@ -75,7 +75,7 @@ final class ResourceLoaderTests: XCTestCase {
         let url = URL.mock()
         let avResourceLoader = AVAssetResourceLoader.mock(url: url)
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: url)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(with: avResourceLoader, requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(with: avResourceLoader, requestInfo: requestInfo)
         
         // WHEN
         let requestShouldWait = resourceLoader.resourceLoader(avResourceLoader,
@@ -105,7 +105,7 @@ final class ResourceLoaderTests: XCTestCase {
         let url = URL.mock()
         let avResourceLoader = AVAssetResourceLoader.mock(url: url)
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: url)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(with: avResourceLoader, requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(with: avResourceLoader, requestInfo: requestInfo)
         
         // WHEN
         let requestShouldWait = resourceLoader.resourceLoader(avResourceLoader,
@@ -137,7 +137,7 @@ final class ResourceLoaderTests: XCTestCase {
         let url = URL.mock()
         let avResourceLoader = AVAssetResourceLoader.mock(url: url)
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: url)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(with: avResourceLoader, requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(with: avResourceLoader, requestInfo: requestInfo)
         let _ = resourceLoader.resourceLoader(avResourceLoader,
                                               shouldWaitForLoadingOfRequestedResource: loadingRequest)
         
@@ -170,7 +170,7 @@ final class ResourceLoaderTests: XCTestCase {
         requestable.dataTaskStub = .mock()
         let avResourceLoader = AVAssetResourceLoader.mock(url: url)
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: url)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(with: avResourceLoader, requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(with: avResourceLoader, requestInfo: requestInfo)
         let _ = resourceLoader.resourceLoader(avResourceLoader,
                                               shouldWaitForLoadingOfRequestedResource: loadingRequest)
         
@@ -202,7 +202,7 @@ final class ResourceLoaderTests: XCTestCase {
         requestable.dataTaskStub = .mock()
         let avResourceLoader = AVAssetResourceLoader.mock(url: url)
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: url)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(with: avResourceLoader, requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(with: avResourceLoader, requestInfo: requestInfo)
         let _ = resourceLoader.resourceLoader(avResourceLoader,
                                               shouldWaitForLoadingOfRequestedResource: loadingRequest)
         
@@ -236,7 +236,7 @@ final class ResourceLoaderTests: XCTestCase {
         requestable.dataTaskStub = .mock()
         let avResourceLoader = AVAssetResourceLoader.mock(url: url)
         let requestInfo = AVAssetResourceLoadingRequest.mockRequestInfo(infoURL: url)
-        let loadingRequest = AVAssetResourceLoadingRequest.mock(with: avResourceLoader, requestInfo: requestInfo)
+        let loadingRequest = AVAssetResourceLoadingRequest.mockWithCustomSetup(with: avResourceLoader, requestInfo: requestInfo)
         let _ = resourceLoader.resourceLoader(avResourceLoader,
                                               shouldWaitForLoadingOfRequestedResource: loadingRequest)
         

--- a/VidLoader/VidLoaderTests/Tests/ExtensionsTests/AVAssetResourceLoadingRequestExtensionsTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/ExtensionsTests/AVAssetResourceLoadingRequestExtensionsTests.swift
@@ -14,11 +14,12 @@ final class AVAssetResourceLoadingRequestTests: XCTestCase {
 
     func test_SetupLoadingRequest_InformationHasSet_RequestGotNewInformation() {
         // GIVEN
-        let resourceLoading = AVAssetResourceLoadingRequest.mock(shouldSwizzle: false)
-        let expectedContentType = "custom_mime"
+        let resourceLoading = AVAssetResourceLoadingRequest.mockWithCustomContentInfoRequest()
+        let expectedContentType = "custom_type"
         let expectedIsByteRangeAccessSupported = true
         let expectedContentLength = 1231
         let response: HTTPURLResponse = .mock(mimeType: expectedContentType, expectedContentLength: expectedContentLength)
+        resourceLoading.contentInformationRequestStub = .mock(loadingRequest: resourceLoading, allowedContentTypes: nil)
         
         // WHEN
         resourceLoading.setup(response: response, data: .mock())
@@ -27,5 +28,52 @@ final class AVAssetResourceLoadingRequestTests: XCTestCase {
         XCTAssertEqual(expectedContentType, resourceLoading.contentInformationRequest?.contentType)
         XCTAssertEqual(expectedIsByteRangeAccessSupported, resourceLoading.contentInformationRequest?.isByteRangeAccessSupported)
         XCTAssertEqual(Int64(expectedContentLength), resourceLoading.contentInformationRequest?.contentLength)
+    }
+    
+    func test_SetupLoadingRequest_AllowedTypesAreEmpty_ContentTypeIsNil() {
+        // GIVEN
+        let resourceLoading = AVAssetResourceLoadingRequest.mockWithCustomContentInfoRequest()
+        let expectedContentType: String? = nil
+        let givenContentType = "custom_type"
+        let response: HTTPURLResponse = .mock(mimeType: givenContentType, expectedContentLength: 10)
+        resourceLoading.contentInformationRequestStub = .mock(loadingRequest: resourceLoading, allowedContentTypes: [])
+        
+        // WHEN
+        resourceLoading.setup(response: response, data: .mock())
+        
+        // THEN
+        XCTAssertEqual(expectedContentType, resourceLoading.contentInformationRequest?.contentType)
+    }
+    
+    func test_SetupLoadingRequest_AllowedTypesDoNotContainGivenType_ContentTypeIsNil() {
+        // GIVEN
+        let resourceLoading = AVAssetResourceLoadingRequest.mockWithCustomContentInfoRequest()
+        let expectedContentType: String? = nil
+        let givenContentType = "custom_type"
+        let allowedTypes = ["random_type1", "random_type2"]
+        let response: HTTPURLResponse = .mock(mimeType: givenContentType, expectedContentLength: 10)
+        resourceLoading.contentInformationRequestStub = .mock(loadingRequest: resourceLoading, allowedContentTypes: allowedTypes as NSArray)
+        
+        // WHEN
+        resourceLoading.setup(response: response, data: .mock())
+        
+        // THEN
+        XCTAssertEqual(expectedContentType, resourceLoading.contentInformationRequest?.contentType)
+    }
+    
+    func test_SetupLoadingRequest_AllowedTypesContainGivenType_ContentTypeIsNil() {
+        // GIVEN
+        let resourceLoading = AVAssetResourceLoadingRequest.mockWithCustomContentInfoRequest()
+        let givenContentType = "custom_type"
+        let expectedContentType = givenContentType
+        let allowedTypes = ["random_type1", givenContentType]
+        let response: HTTPURLResponse = .mock(mimeType: givenContentType, expectedContentLength: 10)
+        resourceLoading.contentInformationRequestStub = .mock(loadingRequest: resourceLoading, allowedContentTypes: allowedTypes as NSArray)
+        
+        // WHEN
+        resourceLoading.setup(response: response, data: .mock())
+        
+        // THEN
+        XCTAssertEqual(expectedContentType, resourceLoading.contentInformationRequest?.contentType)
     }
 }


### PR DESCRIPTION
Starting with iOS 16 if content type is not in the list of the **AVAssetResourceLoader** allowed content types then **AVFoundation** will crash

https://developer.apple.com/documentation/avfoundation/avassetresourceloadingcontentinformationrequest/2936886-allowedcontenttypes

While checking encryption keys I have noticed that each server is returning different mime types like "application/octet-stream", this means that using mime type that server is providing within response can cause crashes if allowed types coming from AVAssetResourceLoader doesn't contain it, in this case we return nil value that is also a recommended from documentation -> **must be set to a value contained in allowedContentTypes or nil**

Fixes #41 
