### PR TITLE
Update resource loader flow

### DIFF
--- a/VidLoader/VidLoader.xcodeproj/project.pbxproj
+++ b/VidLoader/VidLoader.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0B354B012396953C009CE690 /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B354AF72396953C009CE690 /* DataExtensions.swift */; };
 		0B354B022396953C009CE690 /* URLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B354AF82396953C009CE690 /* URLExtensions.swift */; };
 		0B354B032396953C009CE690 /* HTTPURLResponseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B354AF92396953C009CE690 /* HTTPURLResponseExtensions.swift */; };
+		0B4522EA28FA053400B94DD5 /* RegexStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4522E928FA053400B94DD5 /* RegexStrings.swift */; };
 		0B51984C239A648000AEC201 /* FileHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B51984B239A648000AEC201 /* FileHandlerTests.swift */; };
 		0B51984E239A64CB00AEC201 /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B51984D239A64CB00AEC201 /* MockFileManager.swift */; };
 		0B519850239A65BE00AEC201 /* MockVidLoaderExecutionQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B51984F239A65BE00AEC201 /* MockVidLoaderExecutionQueue.swift */; };
@@ -34,6 +35,7 @@
 		0B519860239AC77800AEC201 /* KeyLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B51985F239AC77800AEC201 /* KeyLoaderTests.swift */; };
 		0B519862239AC9EE00AEC201 /* MockSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B519861239AC9EE00AEC201 /* MockSchemeHandler.swift */; };
 		0B519864239AF06300AEC201 /* FunCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B519863239AF06300AEC201 /* FunCheck.swift */; };
+		0B66AF1328FA13C5008D471B /* NSErrorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B66AF1228FA13C5008D471B /* NSErrorExtensions.swift */; };
 		0B7C1C9A23A139A500F9E69A /* VidLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1C9923A139A500F9E69A /* VidLoaderTests.swift */; };
 		0B7C1C9C23A13A1D00F9E69A /* MockSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1C9B23A13A1D00F9E69A /* MockSession.swift */; };
 		0B7C1C9E23A13F6C00F9E69A /* MockPlaylistLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7C1C9D23A13F6C00F9E69A /* MockPlaylistLoadable.swift */; };
@@ -128,6 +130,7 @@
 		0B354AF72396953C009CE690 /* DataExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataExtensions.swift; sourceTree = "<group>"; };
 		0B354AF82396953C009CE690 /* URLExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLExtensions.swift; sourceTree = "<group>"; };
 		0B354AF92396953C009CE690 /* HTTPURLResponseExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPURLResponseExtensions.swift; sourceTree = "<group>"; };
+		0B4522E928FA053400B94DD5 /* RegexStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexStrings.swift; sourceTree = "<group>"; };
 		0B51984B239A648000AEC201 /* FileHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHandlerTests.swift; sourceTree = "<group>"; };
 		0B51984D239A64CB00AEC201 /* MockFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		0B51984F239A65BE00AEC201 /* MockVidLoaderExecutionQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVidLoaderExecutionQueue.swift; sourceTree = "<group>"; };
@@ -140,6 +143,7 @@
 		0B51985F239AC77800AEC201 /* KeyLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyLoaderTests.swift; sourceTree = "<group>"; };
 		0B519861239AC9EE00AEC201 /* MockSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSchemeHandler.swift; sourceTree = "<group>"; };
 		0B519863239AF06300AEC201 /* FunCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunCheck.swift; sourceTree = "<group>"; };
+		0B66AF1228FA13C5008D471B /* NSErrorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSErrorExtensions.swift; sourceTree = "<group>"; };
 		0B7C1C9923A139A500F9E69A /* VidLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VidLoaderTests.swift; sourceTree = "<group>"; };
 		0B7C1C9B23A13A1D00F9E69A /* MockSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSession.swift; sourceTree = "<group>"; };
 		0B7C1C9D23A13F6C00F9E69A /* MockPlaylistLoadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPlaylistLoadable.swift; sourceTree = "<group>"; };
@@ -329,6 +333,7 @@
 				0B1495B423A002C1007ED700 /* CMTimeRangeExtensions.swift */,
 				0B07F6A8249BF00600F99458 /* DownloadValuesExtensions.swift */,
 				0B1DA59528E04260005534F0 /* AVAssetResourceLoadingContentInformationRequestExtensions.swift */,
+				0B66AF1228FA13C5008D471B /* NSErrorExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -502,6 +507,7 @@
 		0BA35D3D23855206004B2F31 /* M3U8Parser */ = {
 			isa = PBXGroup;
 			children = (
+				0B4522E928FA053400B94DD5 /* RegexStrings.swift */,
 				0BA35D3E23855206004B2F31 /* M3U8Error.swift */,
 				0BA35D4023855206004B2F31 /* M3U8Playlist.swift */,
 				0BA35D4123855206004B2F31 /* M3U8Master.swift */,
@@ -687,6 +693,7 @@
 				0BA35D7823855206004B2F31 /* Lens.swift in Sources */,
 				0BA35D6B23855206004B2F31 /* Reachable.swift in Sources */,
 				0BA35D6623855206004B2F31 /* M3U8Error.swift in Sources */,
+				0B4522EA28FA053400B94DD5 /* RegexStrings.swift in Sources */,
 				0BA35D6F23855206004B2F31 /* DownloadState.swift in Sources */,
 				0BA35D6D23855206004B2F31 /* ItemInformation.swift in Sources */,
 				0BA35D6023855206004B2F31 /* VidObserver.swift in Sources */,
@@ -754,6 +761,7 @@
 				0B7C1CA623A1432100F9E69A /* MockAVAssetResourceLoaderDelegate.swift in Sources */,
 				0B519860239AC77800AEC201 /* KeyLoaderTests.swift in Sources */,
 				0B51985A239A805400AEC201 /* SchemeHandlerTests.swift in Sources */,
+				0B66AF1328FA13C5008D471B /* NSErrorExtensions.swift in Sources */,
 				0B519855239A6BC700AEC201 /* NetworkHandlerTests.swift in Sources */,
 				0BE0DF5123AAC6720064F50E /* MockPlaylistParser.swift in Sources */,
 				0B9AD2B423A0317600158D50 /* DataExtensionsTests.swift in Sources */,

--- a/VidLoader/VidLoader/Sources/Classes/M3U8Parser/M3U8Master.swift
+++ b/VidLoader/VidLoader/Sources/Classes/M3U8Parser/M3U8Master.swift
@@ -9,46 +9,49 @@
 import AVFoundation
 
 protocol MasterParser {
-    func adjust(data: Data, completion: @escaping (Result<Data, M3U8Error>) -> Void)
+    func adjust(data: Data, baseURL: URL) -> Result<Data, M3U8Error>
 }
 
 final class M3U8Master: MasterParser {
-    private let executionQueue: VidLoaderExecutionQueueable
-    private let time: () -> DispatchTime
-    
-    init(executionQueue: VidLoaderExecutionQueueable = VidLoaderExecutionQueue(label: "com.vidloader.master_parser_queue"),
-         time: @escaping () -> DispatchTime = { DispatchTime.now() } ) {
-        self.time = time
-        self.executionQueue = executionQueue
-    }
-
-    func adjust(data: Data, completion: @escaping (Result<Data, M3U8Error>) -> Void) {
-        // For m3u8 master file shouldWaitForLoadingOfRequestedResource in iOS 16 behaves differently,
-        // adjustMasterFile is a sync operation without having any request in place.
-        // Session is failling with CoreMediaErrorDomain Code=-12640, to avoid this issue we add an artificial delay for adjustMasterFile (as a temporary solution)
-        // in case session still needs more time to handle AVAssetResourceLoadingRequest finishLoading operation it still may fail
-        executionQueue.asyncAfter(deadline: time() + 0.5) { [weak self] in
-            guard let self = self else { return }
-            completion(self.check(data: data))
-        }
-    }
-    
-    // MARK: - Private functions
-    
-    private func check(data: Data) -> Result<Data, M3U8Error> {
+    func adjust(data: Data, baseURL: URL) -> Result<Data, M3U8Error> {
         guard let response = data.string else {
             return .failure(.dataConversion)
         }
-        guard let data = replacePaths(response: response).data else {
+        let newResponse = replaceRelativePaths(response: response, with: baseURL) |> replaceOriginalSchemes(response:)
+        guard let data = newResponse.data else {
             return .failure(.dataConversion)
         }
         
         return .success(data)
     }
     
-    private func replacePaths(response: String) -> String {
+    // MARK: - Private functions
+    
+    /// Replace all original https schemes with variant scheme
+    /// - Parameter response: m3u8 file string format
+    /// - Returns: Updated response with replaced schemes
+    private func replaceOriginalSchemes(response: String) -> String {
         let suffix = "://"
         return response.replacingOccurrences(of: SchemeType.original.rawValue + suffix,
-                                             with: SchemeType.custom.rawValue + suffix)
+                                             with: SchemeType.variant.rawValue + suffix)
+    }
+    
+    /// Transform all relative URLs in absolute URLs, if playlists has already a scheme then URL will remain untouched
+    /// - Parameters:
+    ///   - response: m3u8 file in string format
+    ///   - baseURL: Master/variant stream resource URL
+    /// - Returns: Updated response with absolute URLs
+    private func replaceRelativePaths(response: String, with baseURL: URL) -> String {
+        guard let newBaseURL = baseURL.withScheme(scheme: .variant)?.deletingLastPathComponent() else {
+            return response
+        }
+        let relativePlaylists = response.matches(for: RegexStrings.relativePlaylist)
+        let uris =  response.matches(for: RegexStrings.uri).filter { URL(string: $0)?.scheme == nil }
+
+        return (relativePlaylists + uris)
+            .reduce(into: response) { result, path in
+                let absoluteURLString = newBaseURL.appendingPathComponent(path).absoluteString
+                result = result.replacingOccurrences(of: path, with: absoluteURLString)
+            }
     }
 }

--- a/VidLoader/VidLoader/Sources/Classes/M3U8Parser/RegexStrings.swift
+++ b/VidLoader/VidLoader/Sources/Classes/M3U8Parser/RegexStrings.swift
@@ -1,0 +1,30 @@
+//
+//  RegexStrings.swift
+//  VidLoader
+//
+//  Created by Petre Plotnic on 14.10.22.
+//
+
+import Foundation
+
+struct RegexStrings {
+    private static let uriKey = "URI=\""
+    // \r\n -> windows
+    // \r -> old macs
+    // \n -> unix
+    private static let newLine = "\\r\\n|\\r|\\n"
+    
+    static let uri = "[\\S\\s\(newLine)]*?\(uriKey)([^\(newLine),\"]+)"
+
+    static let key: String = {
+        let encryptionKey = "#EXT-X-KEY"
+
+        return "\(encryptionKey)\(uri)"
+    }()
+    static let mediaSection: String = {
+        let mediaSectionKey = "#EXT-X-MAP"
+        
+        return "\(mediaSectionKey)(?!https)\(uri)"
+    }()
+    static let relativePlaylist = "(?<=\(newLine))(?!#|https)[\\S]+?(?=\(newLine))"
+}

--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/KeyLoader.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/KeyLoader.swift
@@ -31,7 +31,7 @@ final class KeyLoader: NSObject, KeyLoadable {
                                               mimeType: AVStreamingKeyDeliveryPersistentContentKeyType,
                                               expectedContentLength: persistentKey.count,
                                               textEncodingName: nil)
-                loadingRequest.setup(response: keyResponse, data: persistentKey)
+                loadingRequest.setup(response: keyResponse, data: persistentKey, isEntireLengthAvailableOnDemand: false)
             })
         }
 

--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/PlaylistLoader.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/PlaylistLoader.swift
@@ -39,7 +39,7 @@ final class PlaylistLoader: PlaylistLoadable {
             self?.addStreamResource(streamResource, identifier: identifier)
             completion(.success(()))
         }
-
+        
         var urlRequest = URLRequest(url: url)
         headers?.forEach {
             urlRequest.addValue($0.value, forHTTPHeaderField: $0.key)

--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/SchemeHandler.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/SchemeHandler.swift
@@ -9,29 +9,48 @@
 import AVFoundation
 
 protocol SchemeHandleable {
-    func urlAsset(with mediaURL: URL?) -> Result<AVURLAsset, ResourceLoadingError>
+    func urlAsset(with mediaURL: URL?, data: Data) -> Result<AVURLAsset, ResourceLoadingError>
     func persistentKey(from url: URL) -> Data?
+    func schemeType(from url: URL) -> SchemeType?
 }
 
 enum SchemeType: String {
     case key = "vidloader-encryption-key"
-    case custom = "vidloader-new-scheme"
+    case master = "vidloader-master"
+    case variant = "vidloader-variant"
     case original = "https"
 }
 
 struct SchemeHandler: SchemeHandleable {
-    func urlAsset(with mediaURL: URL?) -> Result<AVURLAsset, ResourceLoadingError> {
-        guard let url = mediaURL?.withScheme(scheme: .custom) else {
+    func urlAsset(with mediaURL: URL?, data: Data) -> Result<AVURLAsset, ResourceLoadingError> {
+        let schemeType = schemeType(from: data)
+        guard let url = mediaURL?.withScheme(scheme: schemeType) else {
             return .failure(.urlScheme)
         }
 
         return .success(AVURLAsset(url: url))
     }
 
+    func schemeType(from url: URL) -> SchemeType? {
+        guard let scheme = url.scheme else {
+            return nil
+        }
+        return SchemeType(rawValue: scheme)
+    }
+
     func persistentKey(from url: URL) -> Data? {
-        guard url.scheme == SchemeType.key.rawValue,
-            let adoptURL = url.withScheme(scheme: nil) else { return nil }
+        guard let adoptURL = url.withScheme(scheme: nil) else { return nil }
 
         return Data(base64Encoded: adoptURL.absoluteString)
+    }
+    
+    // MARK: - Private
+    
+    private func schemeType(from data: Data) -> SchemeType {
+        let variantChunkKey = "#EXTINF"
+        guard let chunkData = variantChunkKey.data else {
+            return .master
+        }
+        return data.range(of: chunkData) == nil ? .master : .variant
     }
 }

--- a/VidLoader/VidLoader/Sources/Extensions/AVAssetResourceLoadingRequestExtensions.swift
+++ b/VidLoader/VidLoader/Sources/Extensions/AVAssetResourceLoadingRequestExtensions.swift
@@ -9,10 +9,13 @@
 import AVFoundation
 
 extension AVAssetResourceLoadingRequest {
-    @objc public func setup(response: URLResponse, data: Data) {
+    @objc public func setup(response: URLResponse, data: Data, isEntireLengthAvailableOnDemand: Bool) {
         contentInformationRequest?.contentType = response.mimeType |> generateAllowedContentType
         contentInformationRequest?.isByteRangeAccessSupported = true
         contentInformationRequest?.contentLength = response.expectedContentLength
+        if #available(iOS 16, *) {
+            contentInformationRequest?.isEntireLengthAvailableOnDemand = isEntireLengthAvailableOnDemand
+        }
         dataRequest?.respond(with: data)
         finishLoading()
     }

--- a/VidLoader/VidLoader/Sources/Models/StreamResource.swift
+++ b/VidLoader/VidLoader/Sources/Models/StreamResource.swift
@@ -8,25 +8,12 @@
 
 import Foundation
 
-private let variantChunkKey = "#EXTINF"
-
 struct StreamResource: Equatable {
-    enum FileType {
-        case master
-        case variant
-    }
     let response: HTTPURLResponse
     let data: Data
-    let fileType: FileType
     
     init(response: HTTPURLResponse, data: Data) {
         self.response = response
         self.data = data
-        switch variantChunkKey.data {
-        case let .some(chunkKey):
-            fileType = data.range(of: chunkKey) == nil ? .master : .variant
-        case .none:
-            fileType = .master
-        }
     }
 }

--- a/VidLoader/VidLoader/Sources/Utils/Requestable.swift
+++ b/VidLoader/VidLoader/Sources/Utils/Requestable.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol Requestable: AnyObject {
-    func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+    func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
 }
 
 extension URLSession: Requestable { }

--- a/VidLoader/VidLoader/Sources/Utils/VidLoaderExecutionQueue.swift
+++ b/VidLoader/VidLoader/Sources/Utils/VidLoaderExecutionQueue.swift
@@ -10,7 +10,6 @@ import Foundation
 
 protocol VidLoaderExecutionQueueable {
     func async(execution: @escaping () -> Void)
-    func asyncAfter(deadline: DispatchTime, execution: @escaping() -> Void)
 }
 
 final class VidLoaderExecutionQueue: VidLoaderExecutionQueueable {
@@ -22,9 +21,5 @@ final class VidLoaderExecutionQueue: VidLoaderExecutionQueueable {
 
     func async(execution: @escaping () -> Void) {
         queue.async { execution() }
-    }
-    
-    func asyncAfter(deadline: DispatchTime, execution: @escaping() -> Void) {
-        queue.asyncAfter(deadline: deadline, execute: execution)
     }
 }

--- a/VidLoader/VidLoader/Sources/VidLoader.swift
+++ b/VidLoader/VidLoader/Sources/VidLoader.swift
@@ -242,13 +242,13 @@ public final class VidLoader: VidLoadable {
 
     private func startNewTaskIfNeeded() {
         if activeItems.filter({ $1.inProgress }).count >= maxConcurrentDownloads { return }
-        guard let streamResource = playlistLoader.nextStreamResource,
-            let item = activeItems[streamResource.0],
-            let url = URL(string: item.mediaLink) else { return }
-        switch schemeHandler.urlAsset(with: url) {
+        guard let (identifier, streamResource) = playlistLoader.nextStreamResource,
+              let item = activeItems[identifier],
+              let url = URL(string: item.mediaLink) else { return }
+        switch schemeHandler.urlAsset(with: url, data: streamResource.data) {
         case .success(let urlAsset):
             startTask(urlAsset: urlAsset,
-                      streamResource: streamResource.1,
+                      streamResource: streamResource,
                       item: item |> ItemInformation._state .~ .running(0))
         case .failure(let error):
             handle(event: .failed(error: .init(error: error)),

--- a/VidLoader/VidLoaderTests/Extensions/AVAssetResourceLoadingRequestExtensions.swift
+++ b/VidLoader/VidLoaderTests/Extensions/AVAssetResourceLoadingRequestExtensions.swift
@@ -29,7 +29,7 @@ extension AVAssetResourceLoadingRequest {
         }
     }
 
-    @objc func mockSetup(response: URLResponse, data: Data) {
+    @objc func mockSetup(response: URLResponse, data: Data, isEntireLengthAvailableOnDemand: Bool) {
         setupFuncDidCall = true
     }
     
@@ -63,7 +63,7 @@ extension AVAssetResourceLoadingRequest {
         return create(with: resourceLoader,
                       requestInfo: requestInfo,
                       requestID: requestID,
-                      swizzleAction: { swizzle(className: self, original: #selector(setup(response:data:)), new: #selector(mockSetup(response:data:))) })
+                      swizzleAction: { swizzle(className: self, original: #selector(setup(response:data:isEntireLengthAvailableOnDemand:)), new: #selector(mockSetup(response:data:isEntireLengthAvailableOnDemand:))) })
     }
 
     static private func create(with resourceLoader: AVAssetResourceLoader = .mock(),

--- a/VidLoader/VidLoaderTests/Extensions/NSErrorExtensions.swift
+++ b/VidLoader/VidLoaderTests/Extensions/NSErrorExtensions.swift
@@ -1,0 +1,15 @@
+//
+//  NSErrorExtensions.swift
+//  VidLoaderTests
+//
+//  Created by Petre Plotnic on 15.10.22.
+//  Copyright © 2022 Petre. All rights reserved.
+//
+
+import Foundation
+
+extension NSError {
+    static func mock(domain: String = "", code: Int = 0, userInfo: [String: Any]? = nil) -> NSError {
+        return NSError(domain: domain, code: code, userInfo: userInfo)
+    }
+}

--- a/VidLoader/VidLoaderTests/Mocks/MockMasterParser.swift
+++ b/VidLoader/VidLoaderTests/Mocks/MockMasterParser.swift
@@ -11,10 +11,10 @@ import Foundation
 
 struct MockMasterParser: MasterParser {
    
-    var adjustFuncCheck = FuncCheck<Data>()
+    var adjustFuncCheck = FuncCheck<(Data, URL)>()
     var adjustStub: Result<Data, M3U8Error> = .success(.mock())
-    func adjust(data: Data, completion: @escaping (Result<Data, M3U8Error>) -> Void) {
-        adjustFuncCheck.call(data)
-        completion(adjustStub)
+    func adjust(data: Data, baseURL: URL) -> Result<Data, M3U8Error> {
+        adjustFuncCheck.call((data, baseURL))
+        return adjustStub
     }
 }

--- a/VidLoader/VidLoaderTests/Mocks/MockSchemeHandler.swift
+++ b/VidLoader/VidLoaderTests/Mocks/MockSchemeHandler.swift
@@ -9,19 +9,26 @@
 @testable import VidLoader
 import AVFoundation
 
-struct MockSchemeHandler: SchemeHandleable {
-    
-    var urlAssetFuncCheck = FuncCheck<URL?>()
-    var urlAssetStub: Result<AVURLAsset, ResourceLoadingError> = .failure(.unknown)
-    func urlAsset(with mediaURL: URL?) -> Result<AVURLAsset, ResourceLoadingError> {
-        urlAssetFuncCheck.call(mediaURL)
-        return urlAssetStub
-    }
-    
+final class MockSchemeHandler: SchemeHandleable {
+
     var persistentKeyFuncCheck = FuncCheck<URL>()
     var persistentKeyStub: Data?
     func persistentKey(from url: URL) -> Data? {
         persistentKeyFuncCheck.call(url)
         return persistentKeyStub
+    }
+
+    var urlAssetFuncCheck = FuncCheck<(URL?, Data)>()
+    var urlAssetStub: Result<AVURLAsset, ResourceLoadingError> = .failure(.unknown)
+    func urlAsset(with mediaURL: URL?, data: Data) -> Result<AVURLAsset, ResourceLoadingError> {
+        urlAssetFuncCheck.call((mediaURL, data))
+        return urlAssetStub
+    }
+    
+    var schemeTypeFuncCheck = FuncCheck<URL>()
+    var schemeTypeStub: SchemeType?
+    func schemeType(from url: URL) -> SchemeType? {
+        schemeTypeFuncCheck.call(url)
+        return schemeTypeStub
     }
 }

--- a/VidLoader/VidLoaderTests/Mocks/MockVidLoaderExecutionQueue.swift
+++ b/VidLoader/VidLoaderTests/Mocks/MockVidLoaderExecutionQueue.swift
@@ -10,12 +10,6 @@
 
 final class MockVidLoaderExecutionQueue: VidLoaderExecutionQueueable {
     
-    var asyncAfterFuncCheck = FuncCheck<DispatchTime>()
-    func asyncAfter(deadline: DispatchTime, execution: @escaping () -> Void) {
-        asyncAfterFuncCheck.call(deadline)
-        execution()
-    }
-    
     var asyncFuncCheck = EmptyFuncCheck()
     func async(execution: @escaping () -> Void) {
         asyncFuncCheck.call()

--- a/VidLoader/VidLoaderTests/Tests/Classes/M3U8Parser/M3U8MasterTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/M3U8Parser/M3U8MasterTests.swift
@@ -10,49 +10,115 @@ import XCTest
 
 final class M3U8MasterTest: XCTestCase {
     private var parser: M3U8Master!
-    private var executionQueue: MockVidLoaderExecutionQueue!
-    private var time: DispatchTime!
     
     override func setUp() {
         super.setUp()
         
-        executionQueue = .init()
-        let newTime = DispatchTime.now()
-        time = newTime
-        let timeCall: () -> DispatchTime = { newTime }
-        parser = M3U8Master(executionQueue: executionQueue, time: timeCall)
+        parser = M3U8Master()
     }
     
-    func test_AdjustMasterScheme_OriginalSchemeExist_SchemeIsReplaced() {
+    func test_AdjustMasterScheme_RelativeURLS_BaseURLAttached() {
         // GIVEN
-        let path = "random_path"
-        let givenString = "\(SchemeType.original.rawValue)://\(path)"
-        let expectedResult: Result<Data, M3U8Error> = .success(.mock(string: "\(SchemeType.custom.rawValue)://\(path)"))
-        let finalResultFuncCheck = FuncCheck<Result<Data, M3U8Error>>()
-        let expectedDelay = time + 0.5
+        let urlPath = "parser.m3u8.test"
+        let givenBaseURL = URL.mock(stringURL: "https://\(urlPath)")
+        let expectedURLString = "\(SchemeType.variant.rawValue)://\(urlPath)/"
+        let master = """
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",DEFAULT=YES,AUTOSELECT=YES,FORCED=NO,LANGUAGE="en",URI="cc/en/en.m3u8"
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="english_64",LANGUAGE="en",NAME="English",AUTOSELECT=YES,DEFAULT=YES,URI="audio_english_64/prog_index.m3u8"
+
+#EXT-X-STREAM-INF:BANDWIDTH=446094,AVERAGE-BANDWIDTH=187133,VIDEO-RANGE=SDR,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=960x540,FRAME-RATE=29.970,AUDIO="english_64",SUBTITLES="subs"
+avc_540p_2000/prog_index.m3u8
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=167915,AVERAGE-BANDWIDTH=49610,CODECS="avc1.4d401f",RESOLUTION=960x540,URI="avc_540p_2000/iframe_index.m3u8"
+"""
+        let expectedMaster = """
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",DEFAULT=YES,AUTOSELECT=YES,FORCED=NO,LANGUAGE="en",URI="\(expectedURLString)cc/en/en.m3u8"
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="english_64",LANGUAGE="en",NAME="English",AUTOSELECT=YES,DEFAULT=YES,URI="\(expectedURLString)audio_english_64/prog_index.m3u8"
+
+#EXT-X-STREAM-INF:BANDWIDTH=446094,AVERAGE-BANDWIDTH=187133,VIDEO-RANGE=SDR,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=960x540,FRAME-RATE=29.970,AUDIO="english_64",SUBTITLES="subs"
+\(expectedURLString)avc_540p_2000/prog_index.m3u8
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=167915,AVERAGE-BANDWIDTH=49610,CODECS="avc1.4d401f",RESOLUTION=960x540,URI="\(expectedURLString)avc_540p_2000/iframe_index.m3u8"
+"""
+        let expectedResult: Result<Data, M3U8Error> = .success(.mock(string: expectedMaster))
         
         // WHEN
-        parser.adjust(data: .mock(string: givenString),
-                      completion: { finalResultFuncCheck.call($0) })
+        let result = parser.adjust(data: .mock(string: master), baseURL: givenBaseURL)
         
         // THEN
-        XCTAssertTrue(finalResultFuncCheck.wasCalled(with: expectedResult))
-        XCTAssertTrue(executionQueue.asyncAfterFuncCheck.wasCalled(with: expectedDelay))
+        XCTAssertEqual(expectedResult, result)
+    }
+    
+    func test_AdjustMasterScheme_AbsoluteURLs_SchemesAreReplaced() {
+        // GIVEN
+        let urlPath = "parser.m3u8.test"
+        let givenBaseURL = URL.mock(stringURL: "https://\(urlPath)")
+        let master = """
+#EXTM3U
+
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",DEFAULT=YES,AUTOSELECT=YES,FORCED=NO,LANGUAGE="en",URI="https://avid.test.co/unknown/videos/en.m3u8"
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2200000
+https://avid.test.co/unknown/videos/best_26075.m3u8
+"""
+        let expectedMaster = """
+#EXTM3U
+
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",DEFAULT=YES,AUTOSELECT=YES,FORCED=NO,LANGUAGE="en",URI="\(SchemeType.variant.rawValue)://avid.test.co/unknown/videos/en.m3u8"
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2200000
+\(SchemeType.variant.rawValue)://avid.test.co/unknown/videos/best_26075.m3u8
+"""
+        let expectedResult: Result<Data, M3U8Error> = .success(.mock(string: expectedMaster))
+        
+        // WHEN
+        let result = parser.adjust(data: .mock(string: master), baseURL: givenBaseURL)
+        
+        // THEN
+        XCTAssertEqual(expectedResult, result)
+    }
+    
+    func test_AdjustMasterScheme_MixedURLs_SchemesAreReplacedAndBaseURLAttached() {
+        // GIVEN
+        let urlPath = "parser.m3u8.test"
+        let givenBaseURL = URL.mock(stringURL: "https://\(urlPath)")
+        let expectedURLString = "\(SchemeType.variant.rawValue)://\(urlPath)/"
+        let master = """
+#EXTM3U
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",DEFAULT=YES,AUTOSELECT=YES,FORCED=NO,LANGUAGE="en",URI="https://avid.test.co/unknown/videos/en.m3u8"
+
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2200000
+https://avid.test.co/unknown/videos/best_26075.m3u8
+
+#EXT-X-STREAM-INF:BANDWIDTH=446094,AVERAGE-BANDWIDTH=187133,VIDEO-RANGE=SDR,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=960x540,FRAME-RATE=29.970,AUDIO="english_64",SUBTITLES="subs"
+avc_540p_2000/prog_index.m3u8
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=167915,AVERAGE-BANDWIDTH=49610,CODECS="avc1.4d401f",RESOLUTION=960x540,URI="avc_540p_2000/iframe_index.m3u8"
+"""
+        let expectedMaster = """
+#EXTM3U
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",DEFAULT=YES,AUTOSELECT=YES,FORCED=NO,LANGUAGE="en",URI="\(SchemeType.variant.rawValue)://avid.test.co/unknown/videos/en.m3u8"
+
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2200000
+\(SchemeType.variant.rawValue)://avid.test.co/unknown/videos/best_26075.m3u8
+
+#EXT-X-STREAM-INF:BANDWIDTH=446094,AVERAGE-BANDWIDTH=187133,VIDEO-RANGE=SDR,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=960x540,FRAME-RATE=29.970,AUDIO="english_64",SUBTITLES="subs"
+\(expectedURLString)avc_540p_2000/prog_index.m3u8
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=167915,AVERAGE-BANDWIDTH=49610,CODECS="avc1.4d401f",RESOLUTION=960x540,URI="\(expectedURLString)avc_540p_2000/iframe_index.m3u8"
+"""
+        let expectedResult: Result<Data, M3U8Error> = .success(.mock(string: expectedMaster))
+        
+        // WHEN
+        let result = parser.adjust(data: .mock(string: master), baseURL: givenBaseURL)
+        
+        // THEN
+        XCTAssertEqual(expectedResult, result)
     }
     
     func test_AdjustMasterScheme_OriginalSchemeNotExist_SchemeIsNotReplaced() {
         // GIVEN
         let givenString = "wrong_scheme://random.path.co"
         let expectedResult: Result<Data, M3U8Error> = .success(.mock(string: givenString))
-        let finalResultFuncCheck = FuncCheck<Result<Data, M3U8Error>>()
-        let expectedDelay = time + 0.5
         
         // WHEN
-        parser.adjust(data: .mock(string: givenString),
-                      completion: { finalResultFuncCheck.call($0) })
+        let result = parser.adjust(data: .mock(string: givenString), baseURL: URL.mock())
         
         // THEN
-        XCTAssertTrue(finalResultFuncCheck.wasCalled(with: expectedResult))
-        XCTAssertTrue(executionQueue.asyncAfterFuncCheck.wasCalled(with: expectedDelay))
+        XCTAssertEqual(expectedResult, result)
     }
 }

--- a/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/SchemeHandlerTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/SchemeHandlerTests.swift
@@ -60,21 +60,94 @@ final class SchemeHandlerTests: XCTestCase {
         let expectedResult: Result<AVURLAsset, ResourceLoadingError> = .failure(.urlScheme)
         
         // WHEN
-        let finalResult = schemeHandler.urlAsset(with: url)
+        let finalResult = schemeHandler.urlAsset(with: url, data: .init())
         
         // THEN
         XCTAssertEqual(expectedResult, finalResult)
     }
     
-    func test_GenerateURLAsset_LinkIsVaild_AssetURLHasNewScheme() {
+    func test_GenerateURLAsset_LinkIsVaild_AssetURLHasMasterScheme() {
         // GIVEN
-        let expectedScheme = SchemeType.custom.rawValue
+        let expectedScheme = SchemeType.master.rawValue
         let url = URL.mock(stringURL: "\(SchemeType.original.rawValue)://url_to_m3u8.co.co")
+        let givenData = Data.mock(string: "#WRONG-E-X-T-I-N-F")
         
         // WHEN
-        let resultScheme = try? schemeHandler.urlAsset(with: url).get().url.scheme
+        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData).get().url.scheme
         
         // THEN
         XCTAssertEqual(expectedScheme, resultScheme)
+    }
+    
+    func test_GenerateURLAsset_LinkIsVaild_AssetURLHasVariantScheme() {
+        // GIVEN
+        let expectedScheme = SchemeType.variant.rawValue
+        let url = URL.mock(stringURL: "\(SchemeType.original.rawValue)://url_to_m3u8.co.co")
+        let givenData = Data.mock(string: "#EXTINF")
+        
+        // WHEN
+        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData).get().url.scheme
+        
+        // THEN
+        XCTAssertEqual(expectedScheme, resultScheme)
+    }
+
+    func test_CheckSchemeType_URLContainsHttps_OriginalSchemeTypeIsReturned() {
+        // GIVEN
+        let expectedScheme = SchemeType.original
+        let url = URL.mock(stringURL: "https://url_to_m3u8.co.co")
+        
+        // WHEN
+        let resultScheme = schemeHandler.schemeType(from: url)
+        
+        // THEN
+        XCTAssertEqual(expectedScheme, resultScheme)
+    }
+    
+    func test_CheckSchemeType_URLContainsVariantName_VariantSchemeTypeIsReturned() {
+        // GIVEN
+        let expectedScheme = SchemeType.variant
+        let url = URL.mock(stringURL: "vidloader-variant://url_to_m3u8.co.co")
+        
+        // WHEN
+        let resultScheme = schemeHandler.schemeType(from: url)
+        
+        // THEN
+        XCTAssertEqual(expectedScheme, resultScheme)
+    }
+    
+    func test_CheckSchemeType_URLContainsMasterName_MasterSchemeTypeIsReturned() {
+        // GIVEN
+        let expectedScheme = SchemeType.master
+        let url = URL.mock(stringURL: "vidloader-master://url_to_m3u8.co.co")
+        
+        // WHEN
+        let resultScheme = schemeHandler.schemeType(from: url)
+        
+        // THEN
+        XCTAssertEqual(expectedScheme, resultScheme)
+    }
+    
+    func test_CheckSchemeType_URLContainsKeyName_KeySchemeTypeIsReturned() {
+        // GIVEN
+        let expectedScheme = SchemeType.key
+        let url = URL.mock(stringURL: "vidloader-encryption-key://url_to_m3u8.co.co")
+        
+        // WHEN
+        let resultScheme = schemeHandler.schemeType(from: url)
+        
+        // THEN
+        XCTAssertEqual(expectedScheme, resultScheme)
+    }
+    
+    func test_CheckSchemeType_URLContainsUnkownName_NilSchemeTypeIsReturned() {
+        // GIVEN
+        let url = URL.mock(stringURL: "new_unknown_scheme://url_to_m3u8.co.co")
+        
+        // WHEN
+        let resultScheme = schemeHandler.schemeType(from: url)
+        
+        // THEN
+        XCTAssertNil(resultScheme)
     }
 }

--- a/VidLoader/VidLoaderTests/Tests/Classes/Session/DownloadErrorTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/Session/DownloadErrorTests.swift
@@ -24,7 +24,7 @@ final class DownloadErrorTests: XCTestCase {
     
     func test_CreateLoaderError_givenErrorExist_ErrorIsConvertedFromGiven() {
         // GIVEN
-        let givenError = NSError(domain: "custom_damain", code: -983, userInfo: nil)
+        let givenError = NSError.mock()
         let expectedError: DownloadError = .custom(VidLoaderError(error: givenError))
         
         // WHEN
@@ -34,4 +34,51 @@ final class DownloadErrorTests: XCTestCase {
         XCTAssertEqual(expectedError, resultError)
     }
     
+    func test_GenerateTwoErrors_BothHaveUnknownType_ErrorsAreEqual() {
+        // GIVEN
+        let firstError: DownloadError = .unknown
+        let secondError: DownloadError = .unknown
+        
+        // WHEN
+        let areErrorsEqual = firstError == secondError
+        
+        // THEN
+        XCTAssertTrue(areErrorsEqual)
+    }
+    
+    func test_GenerateTwoErrors_BothAreTaskErrors_ErrorsAreEqual() {
+        // GIVEN
+        let firstError: DownloadError = .taskNotCreated
+        let secondError: DownloadError = .taskNotCreated
+        
+        // WHEN
+        let areErrorsEqual = firstError == secondError
+        
+        // THEN
+        XCTAssertTrue(areErrorsEqual)
+    }
+    
+    func test_GenerateTwoErrors_BothAreCustomErrors_ErrorsAreEqual() {
+        // GIVEN
+        let firstError: DownloadError = .custom(VidLoaderError(error: NSError.mock(code: 1)))
+        let secondError: DownloadError = .custom(VidLoaderError(error: NSError.mock(code: 2)))
+        
+        // WHEN
+        let areErrorsEqual = firstError == secondError
+        
+        // THEN
+        XCTAssertTrue(areErrorsEqual)
+    }
+    
+    func test_GenerateTwoErrors_ErrorsAreDifferent_ErrorsAreNotEqual() {
+        // GIVEN
+        let firstError: DownloadError = .custom(VidLoaderError(error: NSError.mock(code: 1)))
+        let secondError: DownloadError = .unknown
+        
+        // WHEN
+        let areErrorsEqual = firstError == secondError
+        
+        // THEN
+        XCTAssertFalse(areErrorsEqual)
+    }
 }

--- a/VidLoader/VidLoaderTests/Tests/ExtensionsTests/AVAssetResourceLoadingRequestExtensionsTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/ExtensionsTests/AVAssetResourceLoadingRequestExtensionsTests.swift
@@ -18,16 +18,20 @@ final class AVAssetResourceLoadingRequestTests: XCTestCase {
         let expectedContentType = "custom_type"
         let expectedIsByteRangeAccessSupported = true
         let expectedContentLength = 1231
+        let expectedEntireLengthAvailableOnDemand = true
         let response: HTTPURLResponse = .mock(mimeType: expectedContentType, expectedContentLength: expectedContentLength)
         resourceLoading.contentInformationRequestStub = .mock(loadingRequest: resourceLoading, allowedContentTypes: nil)
         
         // WHEN
-        resourceLoading.setup(response: response, data: .mock())
+        resourceLoading.setup(response: response, data: .mock(), isEntireLengthAvailableOnDemand: true)
         
         // THEN
         XCTAssertEqual(expectedContentType, resourceLoading.contentInformationRequest?.contentType)
         XCTAssertEqual(expectedIsByteRangeAccessSupported, resourceLoading.contentInformationRequest?.isByteRangeAccessSupported)
         XCTAssertEqual(Int64(expectedContentLength), resourceLoading.contentInformationRequest?.contentLength)
+        if #available(iOS 16, *) {
+            XCTAssertEqual(expectedEntireLengthAvailableOnDemand, resourceLoading.contentInformationRequest?.isEntireLengthAvailableOnDemand)
+        }
     }
     
     func test_SetupLoadingRequest_AllowedTypesAreEmpty_ContentTypeIsNil() {
@@ -35,14 +39,18 @@ final class AVAssetResourceLoadingRequestTests: XCTestCase {
         let resourceLoading = AVAssetResourceLoadingRequest.mockWithCustomContentInfoRequest()
         let expectedContentType: String? = nil
         let givenContentType = "custom_type"
+        let expectedEntireLengthAvailableOnDemand = false
         let response: HTTPURLResponse = .mock(mimeType: givenContentType, expectedContentLength: 10)
         resourceLoading.contentInformationRequestStub = .mock(loadingRequest: resourceLoading, allowedContentTypes: [])
         
         // WHEN
-        resourceLoading.setup(response: response, data: .mock())
+        resourceLoading.setup(response: response, data: .mock(), isEntireLengthAvailableOnDemand: false)
         
         // THEN
         XCTAssertEqual(expectedContentType, resourceLoading.contentInformationRequest?.contentType)
+        if #available(iOS 16, *) {
+            XCTAssertEqual(expectedEntireLengthAvailableOnDemand, resourceLoading.contentInformationRequest?.isEntireLengthAvailableOnDemand)
+        }
     }
     
     func test_SetupLoadingRequest_AllowedTypesDoNotContainGivenType_ContentTypeIsNil() {
@@ -51,14 +59,18 @@ final class AVAssetResourceLoadingRequestTests: XCTestCase {
         let expectedContentType: String? = nil
         let givenContentType = "custom_type"
         let allowedTypes = ["random_type1", "random_type2"]
+        let expectedEntireLengthAvailableOnDemand = true
         let response: HTTPURLResponse = .mock(mimeType: givenContentType, expectedContentLength: 10)
         resourceLoading.contentInformationRequestStub = .mock(loadingRequest: resourceLoading, allowedContentTypes: allowedTypes as NSArray)
         
         // WHEN
-        resourceLoading.setup(response: response, data: .mock())
+        resourceLoading.setup(response: response, data: .mock(), isEntireLengthAvailableOnDemand: true)
         
         // THEN
         XCTAssertEqual(expectedContentType, resourceLoading.contentInformationRequest?.contentType)
+        if #available(iOS 16, *) {
+            XCTAssertEqual(expectedEntireLengthAvailableOnDemand, resourceLoading.contentInformationRequest?.isEntireLengthAvailableOnDemand)
+        }
     }
     
     func test_SetupLoadingRequest_AllowedTypesContainGivenType_ContentTypeIsNil() {
@@ -67,13 +79,17 @@ final class AVAssetResourceLoadingRequestTests: XCTestCase {
         let givenContentType = "custom_type"
         let expectedContentType = givenContentType
         let allowedTypes = ["random_type1", givenContentType]
+        let expectedEntireLengthAvailableOnDemand = false
         let response: HTTPURLResponse = .mock(mimeType: givenContentType, expectedContentLength: 10)
         resourceLoading.contentInformationRequestStub = .mock(loadingRequest: resourceLoading, allowedContentTypes: allowedTypes as NSArray)
         
         // WHEN
-        resourceLoading.setup(response: response, data: .mock())
+        resourceLoading.setup(response: response, data: .mock(), isEntireLengthAvailableOnDemand: false)
         
         // THEN
         XCTAssertEqual(expectedContentType, resourceLoading.contentInformationRequest?.contentType)
+        if #available(iOS 16, *) {
+            XCTAssertEqual(expectedEntireLengthAvailableOnDemand, resourceLoading.contentInformationRequest?.isEntireLengthAvailableOnDemand)
+        }
     }
 }

--- a/VidLoader/VidLoaderTests/Tests/Models/StreamResourceTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Models/StreamResourceTests.swift
@@ -15,7 +15,6 @@ final class StreamResourceTests: XCTestCase {
         // GIVEN
         let givenData = "no_chunk_key_inside".data!
         let givenResponse = HTTPURLResponse.mock()
-        let expectedFileType: StreamResource.FileType = .master
         
         // WHEN
         let resultStream = StreamResource(response: givenResponse, data: givenData)
@@ -23,7 +22,6 @@ final class StreamResourceTests: XCTestCase {
         // THEN
         XCTAssertEqual(givenData, resultStream.data)
         XCTAssertEqual(givenResponse, resultStream.response)
-        XCTAssertEqual(expectedFileType, resultStream.fileType)
     }
     
     func test_GenerateStreamResource_WithChunkKey_FileTypeVariant() {
@@ -31,7 +29,6 @@ final class StreamResourceTests: XCTestCase {
         let variantChunkKey = "#EXTINF"
         let givenData = "chunk_key_inside\(variantChunkKey)".data!
         let givenResponse = HTTPURLResponse.mock()
-        let expectedFileType: StreamResource.FileType = .variant
         
         // WHEN
         let resultStream = StreamResource(response: givenResponse, data: givenData)
@@ -39,6 +36,5 @@ final class StreamResourceTests: XCTestCase {
         // THEN
         XCTAssertEqual(givenData, resultStream.data)
         XCTAssertEqual(givenResponse, resultStream.response)
-        XCTAssertEqual(expectedFileType, resultStream.fileType)
     }
 }

--- a/VidLoader/VidLoaderTests/Tests/VidLoaderTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/VidLoaderTests.swift
@@ -372,7 +372,7 @@ final class VidLoaderTests: XCTestCase {
         session.setupStub?(.keyLoaded, givenItem)
         
         // THEN
-        XCTAssertTrue(schemeHandler.urlAssetFuncCheck.wasCalled(with: givenURL))
+        XCTAssertEqual(givenURL, schemeHandler.urlAssetFuncCheck.arguments?.0)
         XCTAssertEqual(observersHandler.fireFuncCheck.count, 4)
         XCTAssertEqual(observersHandler.fireFuncCheck.arguments?.0, ObserverType.single(givenIdentifier))
         XCTAssertEqual(observersHandler.fireFuncCheck.arguments?.1, expectedItem)
@@ -397,7 +397,7 @@ final class VidLoaderTests: XCTestCase {
         session.setupStub?(.keyLoaded, givenItem)
         
         // THEN
-        XCTAssertTrue(schemeHandler.urlAssetFuncCheck.wasCalled(with: givenURL))
+        XCTAssertEqual(givenURL, schemeHandler.urlAssetFuncCheck.arguments?.0)
         XCTAssertEqual(observersHandler.fireFuncCheck.count, 2)
         XCTAssertEqual(observersHandler.fireFuncCheck.arguments?.0, ObserverType.single(givenIdentifier))
         XCTAssertEqual(observersHandler.fireFuncCheck.arguments?.1, expectedItem)
@@ -422,7 +422,7 @@ final class VidLoaderTests: XCTestCase {
         session.setupStub?(.keyLoaded, givenItem)
         
         // THEN
-        XCTAssertTrue(schemeHandler.urlAssetFuncCheck.wasCalled(with: givenURL))
+        XCTAssertEqual(givenURL, schemeHandler.urlAssetFuncCheck.arguments?.0)
         XCTAssertEqual(observersHandler.fireFuncCheck.count, 2)
         XCTAssertEqual(observersHandler.fireFuncCheck.arguments?.0, ObserverType.single(givenIdentifier))
         XCTAssertEqual(observersHandler.fireFuncCheck.arguments?.1, expectedItem)


### PR DESCRIPTION
 ```
final class ResourceLoader
***
func resourceLoader(_ resourceLoader: AVAssetResourceLoader,
                        shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
```
in iOS 16 **shouldWaitForLoadingOfRequestedResource**  behaves differently, it is called multiple times for the same resource.
Previously we used **StreamResource** to check if we need to perform master OR variant actions.

I have updated the code taking the URL scheme as the source of truth while splitting the custom scheme in 2 additional schemes:
- variant scheme -> vidloader-variant
- master scheme -> vidloader-master

After modification if **shouldWaitForLoadingOfRequestedResource** is called for the same resource multiple times we don't have anymore issues with nullifying the **StreamResource**


Also iOS 16 came with a new **isEntireLengthAvailableOnDemand** Bool in the AVFoundation -> https://developer.apple.com/documentation/avfoundation/avassetresourceloadingcontentinformationrequest/3950864-isentirelengthavailableondemand/
Starting with this PR it will be used