### PR TITLE
Reopen: Possibility to add cookies to AVURLAsset and HTTPCookieStorage

### DIFF
--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/SchemeHandler.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/SchemeHandler.swift
@@ -30,9 +30,9 @@ struct SchemeHandler: SchemeHandleable {
         
         var options = [String: Any]()
         if let urlAssetCookies = urlAssetCookies {
-                 options["AVURLAssetHTTPHeaderFieldsKey"] = urlAssetCookies.values
-              }
-
+            options["AVURLAssetHTTPHeaderFieldsKey"] = HTTPCookie.requestHeaderFields(with: urlAssetCookies.values)
+        }
+        
         return .success(AVURLAsset(url: url, options: options))
     }
 

--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/SchemeHandler.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/SchemeHandler.swift
@@ -9,7 +9,7 @@
 import AVFoundation
 
 protocol SchemeHandleable {
-    func urlAsset(with mediaURL: URL?, data: Data, urlAssetCookies: URLAssetCookies?) -> Result<AVURLAsset, ResourceLoadingError>
+    func urlAsset(with mediaURL: URL?, data: Data, headers: [String: String]?) -> Result<AVURLAsset, ResourceLoadingError>
     func persistentKey(from url: URL) -> Data?
     func schemeType(from url: URL) -> SchemeType?
 }
@@ -22,15 +22,15 @@ enum SchemeType: String {
 }
 
 struct SchemeHandler: SchemeHandleable {
-    func urlAsset(with mediaURL: URL?, data: Data, urlAssetCookies: URLAssetCookies?) -> Result<AVURLAsset, ResourceLoadingError> {
+    func urlAsset(with mediaURL: URL?, data: Data, headers: [String: String]?) -> Result<AVURLAsset, ResourceLoadingError> {
         let schemeType = schemeType(from: data)
         guard let url = mediaURL?.withScheme(scheme: schemeType) else {
             return .failure(.urlScheme)
         }
         
         var options = [String: Any]()
-        if let urlAssetCookies = urlAssetCookies {
-            options["AVURLAssetHTTPHeaderFieldsKey"] = HTTPCookie.requestHeaderFields(with: urlAssetCookies.values)
+        if let headers = headers {
+            options["AVURLAssetHTTPHeaderFieldsKey"] = headers
         }
         
         return .success(AVURLAsset(url: url, options: options))

--- a/VidLoader/VidLoader/Sources/Classes/ResourceLoader/SchemeHandler.swift
+++ b/VidLoader/VidLoader/Sources/Classes/ResourceLoader/SchemeHandler.swift
@@ -9,7 +9,7 @@
 import AVFoundation
 
 protocol SchemeHandleable {
-    func urlAsset(with mediaURL: URL?, data: Data) -> Result<AVURLAsset, ResourceLoadingError>
+    func urlAsset(with mediaURL: URL?, data: Data, urlAssetCookies: URLAssetCookies?) -> Result<AVURLAsset, ResourceLoadingError>
     func persistentKey(from url: URL) -> Data?
     func schemeType(from url: URL) -> SchemeType?
 }
@@ -22,13 +22,18 @@ enum SchemeType: String {
 }
 
 struct SchemeHandler: SchemeHandleable {
-    func urlAsset(with mediaURL: URL?, data: Data) -> Result<AVURLAsset, ResourceLoadingError> {
+    func urlAsset(with mediaURL: URL?, data: Data, urlAssetCookies: URLAssetCookies?) -> Result<AVURLAsset, ResourceLoadingError> {
         let schemeType = schemeType(from: data)
         guard let url = mediaURL?.withScheme(scheme: schemeType) else {
             return .failure(.urlScheme)
         }
+        
+        var options = [String: Any]()
+        if let urlAssetCookies = urlAssetCookies {
+                 options["AVURLAssetHTTPHeaderFieldsKey"] = urlAssetCookies.values
+              }
 
-        return .success(AVURLAsset(url: url))
+        return .success(AVURLAsset(url: url, options: options))
     }
 
     func schemeType(from url: URL) -> SchemeType? {

--- a/VidLoader/VidLoader/Sources/Models/ItemInformation.swift
+++ b/VidLoader/VidLoader/Sources/Models/ItemInformation.swift
@@ -114,7 +114,8 @@ extension ItemInformation {
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $0, downloadedBytes: $1.downloadedBytes,
                                artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
-                               headers: $1.headers) }
+                               headers: $1.headers,
+                               urlAssetCookies: $1.urlAssetCookies) }
     )
 
     static let _path = Lens<ItemInformation, String?>(
@@ -123,7 +124,8 @@ extension ItemInformation {
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $1.state, downloadedBytes: $1.downloadedBytes,
                                artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
-                               headers: $1.headers) }
+                               headers: $1.headers,
+                               urlAssetCookies: $1.urlAssetCookies) }
     )
 
     static let _progress = Lens<ItemInformation, Double>(
@@ -132,7 +134,8 @@ extension ItemInformation {
                                mediaLink: $1.mediaLink, progress: $0,
                                state: $1.state, downloadedBytes: $1.downloadedBytes,
                                artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
-                               headers: $1.headers) }
+                               headers: $1.headers,
+                               urlAssetCookies: $1.urlAssetCookies) }
     )
 
     static let _downloadedBytes = Lens<ItemInformation, Int>(
@@ -141,6 +144,7 @@ extension ItemInformation {
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $1.state, downloadedBytes: $0,
                                artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
-                               headers: $1.headers) }
+                               headers: $1.headers,
+                               urlAssetCookies: $1.urlAssetCookies) }
     )
 }

--- a/VidLoader/VidLoader/Sources/Models/ItemInformation.swift
+++ b/VidLoader/VidLoader/Sources/Models/ItemInformation.swift
@@ -32,12 +32,15 @@ public struct ItemInformation: Codable, Equatable {
     let minRequiredBitrate: Int?
     ///HTTPHeader to be used when headers is necessary to download m3u8 or key files
     let headers: [String: String]?
+    
+    let urlAssetCookies: URLAssetCookies?
 
     init(identifier: String, title: String?, path: String? = nil,
          mediaLink: String = "", progress: Double = 0,
          state: DownloadState, downloadedBytes: Int = 0,
          artworkData: Data?, minRequiredBitrate: Int?,
-         headers: [String: String]? = nil) {
+         headers: [String: String]? = nil,
+         urlAssetCookies: URLAssetCookies? = nil) {
         self.identifier = identifier
         self.title = title
         self.path = path
@@ -48,6 +51,7 @@ public struct ItemInformation: Codable, Equatable {
         self.artworkData = artworkData
         self.minRequiredBitrate = minRequiredBitrate
         self.headers = headers
+        self.urlAssetCookies = urlAssetCookies
     }
 
     public var location: URL? {

--- a/VidLoader/VidLoader/Sources/Models/ItemInformation.swift
+++ b/VidLoader/VidLoader/Sources/Models/ItemInformation.swift
@@ -32,8 +32,6 @@ public struct ItemInformation: Codable, Equatable {
     let minRequiredBitrate: Int?
     ///HTTPHeader to be used when headers is necessary to download m3u8 or key files
     let headers: [String: String]?
-    
-    let urlAssetCookies: URLAssetCookies?
 
     init(identifier: String, title: String?, path: String? = nil,
          mediaLink: String = "", progress: Double = 0,
@@ -51,7 +49,6 @@ public struct ItemInformation: Codable, Equatable {
         self.artworkData = artworkData
         self.minRequiredBitrate = minRequiredBitrate
         self.headers = headers
-        self.urlAssetCookies = urlAssetCookies
     }
 
     public var location: URL? {
@@ -114,8 +111,7 @@ extension ItemInformation {
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $0, downloadedBytes: $1.downloadedBytes,
                                artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
-                               headers: $1.headers,
-                               urlAssetCookies: $1.urlAssetCookies) }
+                               headers: $1.headers) }
     )
 
     static let _path = Lens<ItemInformation, String?>(
@@ -124,8 +120,7 @@ extension ItemInformation {
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $1.state, downloadedBytes: $1.downloadedBytes,
                                artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
-                               headers: $1.headers,
-                               urlAssetCookies: $1.urlAssetCookies) }
+                               headers: $1.headers) }
     )
 
     static let _progress = Lens<ItemInformation, Double>(
@@ -134,8 +129,7 @@ extension ItemInformation {
                                mediaLink: $1.mediaLink, progress: $0,
                                state: $1.state, downloadedBytes: $1.downloadedBytes,
                                artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
-                               headers: $1.headers,
-                               urlAssetCookies: $1.urlAssetCookies) }
+                               headers: $1.headers) }
     )
 
     static let _downloadedBytes = Lens<ItemInformation, Int>(
@@ -144,7 +138,6 @@ extension ItemInformation {
                                mediaLink: $1.mediaLink, progress: $1.progress,
                                state: $1.state, downloadedBytes: $0,
                                artworkData: $1.artworkData, minRequiredBitrate: $1.minRequiredBitrate,
-                               headers: $1.headers,
-                               urlAssetCookies: $1.urlAssetCookies) }
+                               headers: $1.headers) }
     )
 }

--- a/VidLoader/VidLoader/Sources/Models/URLAssetCookies.swift
+++ b/VidLoader/VidLoader/Sources/Models/URLAssetCookies.swift
@@ -23,6 +23,28 @@ struct URLAssetCookies : Codable, Equatable {
         self.values = values
     }
     
+    public init(domain: String?, headers: [String: String]?) {
+        
+        var cookies:[HTTPCookie] = []
+        if let domain = domain, let headers = headers {
+            for key in headers.keys {
+                let cookie: [HTTPCookiePropertyKey : Any] = [
+                    HTTPCookiePropertyKey.domain: domain,
+                    HTTPCookiePropertyKey.path: "/",
+                    HTTPCookiePropertyKey.secure: true,
+                    HTTPCookiePropertyKey.init("HttpsOnly"): true,
+                    HTTPCookiePropertyKey.value: headers[key] ?? "",
+                    HTTPCookiePropertyKey.name: key,
+                ]
+                if let httpCookie = HTTPCookie(properties: cookie) {
+                    cookies.append(httpCookie)
+                }
+            }
+        }
+        self.values = cookies
+    }
+    
+    
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         let data = try NSKeyedArchiver.archivedData(withRootObject: values, requiringSecureCoding: false)

--- a/VidLoader/VidLoader/Sources/Models/URLAssetCookies.swift
+++ b/VidLoader/VidLoader/Sources/Models/URLAssetCookies.swift
@@ -1,0 +1,31 @@
+//
+//  URLAssetCookies.swift
+//  VidLoader
+//
+//  Created by Marcos Joshoa on 29/03/23.
+//
+
+import Foundation
+
+struct URLAssetCookies : Codable, Equatable {
+    let values: [HTTPCookie]
+    
+    public enum Error: Swift.Error {
+        case unarchiveFailed
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let data = try container.decode(Data.self)
+        guard let values = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? [HTTPCookie] else {
+            throw Error.unarchiveFailed
+        }
+        self.values = values
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        let data = try NSKeyedArchiver.archivedData(withRootObject: values, requiringSecureCoding: false)
+        try container.encode(data)
+    }
+}

--- a/VidLoader/VidLoader/Sources/Models/URLAssetCookies.swift
+++ b/VidLoader/VidLoader/Sources/Models/URLAssetCookies.swift
@@ -14,15 +14,6 @@ struct URLAssetCookies : Codable, Equatable {
         case unarchiveFailed
     }
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let data = try container.decode(Data.self)
-        guard let values = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? [HTTPCookie] else {
-            throw Error.unarchiveFailed
-        }
-        self.values = values
-    }
-    
     public init(url: URL, headers: [String: String]?) {
         var domain: String?
         if #available(iOS 16.0, *) {
@@ -50,10 +41,22 @@ struct URLAssetCookies : Codable, Equatable {
         self.values = cookies
     }
     
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let data = try container.decode(Data.self)
+        guard let values = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? [HTTPCookie] else {
+            throw Error.unarchiveFailed
+        }
+        self.values = values
+    }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         let data = try NSKeyedArchiver.archivedData(withRootObject: values, requiringSecureCoding: false)
         try container.encode(data)
+    }
+    
+    public func getRequestHeaderFields() -> [String: String]? {
+        return HTTPCookie.requestHeaderFields(with: values)
     }
 }

--- a/VidLoader/VidLoader/Sources/Models/URLAssetCookies.swift
+++ b/VidLoader/VidLoader/Sources/Models/URLAssetCookies.swift
@@ -23,7 +23,13 @@ struct URLAssetCookies : Codable, Equatable {
         self.values = values
     }
     
-    public init(domain: String?, headers: [String: String]?) {
+    public init(url: URL, headers: [String: String]?) {
+        var domain: String?
+        if #available(iOS 16.0, *) {
+            domain = url.host()
+        } else {
+            domain = url.host
+        }
         
         var cookies:[HTTPCookie] = []
         if let domain = domain, let headers = headers {

--- a/VidLoader/VidLoader/Sources/VidLoader.swift
+++ b/VidLoader/VidLoader/Sources/VidLoader.swift
@@ -119,12 +119,6 @@ public final class VidLoader: VidLoadable {
         let identifier = values.identifier
         guard activeItems[identifier] == nil else { return }
         let url = values.url
-        var domain: String?
-        if #available(iOS 16.0, *) {
-            domain = url.host()
-        } else {
-            domain = url.host
-        }
         let item = ItemInformation(identifier: identifier,
                                    title: values.title.removingIllegalCharacters,
                                    mediaLink: url.absoluteString,
@@ -132,7 +126,7 @@ public final class VidLoader: VidLoadable {
                                    artworkData: values.artworkData,
                                    minRequiredBitrate: values.minRequiredBitrate,
                                    headers: values.headers,
-                                   urlAssetCookies: URLAssetCookies(domain: domain, headers: values.headers))
+                                   urlAssetCookies: URLAssetCookies(url: url, headers: values.headers))
         activeItems[identifier] = item
         handle(event: .prefetching, activeItem: item)
         session.task(identifier: identifier, completion: { [weak self] task in

--- a/VidLoader/VidLoader/Sources/VidLoader.swift
+++ b/VidLoader/VidLoader/Sources/VidLoader.swift
@@ -245,7 +245,7 @@ public final class VidLoader: VidLoadable {
         guard let (identifier, streamResource) = playlistLoader.nextStreamResource,
               let item = activeItems[identifier],
               let url = URL(string: item.mediaLink) else { return }
-        switch schemeHandler.urlAsset(with: url, data: streamResource.data) {
+        switch schemeHandler.urlAsset(with: url, data: streamResource.data, urlAssetCookies: item.urlAssetCookies) {
         case .success(let urlAsset):
             startTask(urlAsset: urlAsset,
                       streamResource: streamResource,

--- a/VidLoader/VidLoader/Sources/VidLoader.swift
+++ b/VidLoader/VidLoader/Sources/VidLoader.swift
@@ -119,14 +119,14 @@ public final class VidLoader: VidLoadable {
         let identifier = values.identifier
         guard activeItems[identifier] == nil else { return }
         let url = values.url
+        let urlAssetCookies = URLAssetCookies(url: url, headers: values.headers)
         let item = ItemInformation(identifier: identifier,
                                    title: values.title.removingIllegalCharacters,
                                    mediaLink: url.absoluteString,
                                    state: .unknown,
                                    artworkData: values.artworkData,
                                    minRequiredBitrate: values.minRequiredBitrate,
-                                   headers: values.headers,
-                                   urlAssetCookies: URLAssetCookies(url: url, headers: values.headers))
+                                   headers: urlAssetCookies.getRequestHeaderFields())
         activeItems[identifier] = item
         handle(event: .prefetching, activeItem: item)
         session.task(identifier: identifier, completion: { [weak self] task in
@@ -246,7 +246,7 @@ public final class VidLoader: VidLoadable {
         guard let (identifier, streamResource) = playlistLoader.nextStreamResource,
               let item = activeItems[identifier],
               let url = URL(string: item.mediaLink) else { return }
-        switch schemeHandler.urlAsset(with: url, data: streamResource.data, urlAssetCookies: item.urlAssetCookies) {
+        switch schemeHandler.urlAsset(with: url, data: streamResource.data, headers: item.headers) {
         case .success(let urlAsset):
             startTask(urlAsset: urlAsset,
                       streamResource: streamResource,

--- a/VidLoader/VidLoader/Sources/VidLoader.swift
+++ b/VidLoader/VidLoader/Sources/VidLoader.swift
@@ -119,13 +119,20 @@ public final class VidLoader: VidLoadable {
         let identifier = values.identifier
         guard activeItems[identifier] == nil else { return }
         let url = values.url
+        var domain: String?
+        if #available(iOS 16.0, *) {
+            domain = url.host()
+        } else {
+            domain = url.host
+        }
         let item = ItemInformation(identifier: identifier,
                                    title: values.title.removingIllegalCharacters,
                                    mediaLink: url.absoluteString,
                                    state: .unknown,
                                    artworkData: values.artworkData,
                                    minRequiredBitrate: values.minRequiredBitrate,
-                                   headers: values.headers)
+                                   headers: values.headers,
+                                   urlAssetCookies: URLAssetCookies(domain: domain, headers: values.headers))
         activeItems[identifier] = item
         handle(event: .prefetching, activeItem: item)
         session.task(identifier: identifier, completion: { [weak self] task in

--- a/VidLoader/VidLoaderTests/Mocks/MockSchemeHandler.swift
+++ b/VidLoader/VidLoaderTests/Mocks/MockSchemeHandler.swift
@@ -20,7 +20,7 @@ final class MockSchemeHandler: SchemeHandleable {
 
     var urlAssetFuncCheck = FuncCheck<(URL?, Data)>()
     var urlAssetStub: Result<AVURLAsset, ResourceLoadingError> = .failure(.unknown)
-    func urlAsset(with mediaURL: URL?, data: Data) -> Result<AVURLAsset, ResourceLoadingError> {
+    func urlAsset(with mediaURL: URL?, data: Data, urlAssetCookies: URLAssetCookies?) -> Result<AVURLAsset, ResourceLoadingError> {
         urlAssetFuncCheck.call((mediaURL, data))
         return urlAssetStub
     }

--- a/VidLoader/VidLoaderTests/Mocks/MockSchemeHandler.swift
+++ b/VidLoader/VidLoaderTests/Mocks/MockSchemeHandler.swift
@@ -20,7 +20,7 @@ final class MockSchemeHandler: SchemeHandleable {
 
     var urlAssetFuncCheck = FuncCheck<(URL?, Data)>()
     var urlAssetStub: Result<AVURLAsset, ResourceLoadingError> = .failure(.unknown)
-    func urlAsset(with mediaURL: URL?, data: Data, urlAssetCookies: URLAssetCookies?) -> Result<AVURLAsset, ResourceLoadingError> {
+    func urlAsset(with mediaURL: URL?, data: Data, headers: [String: String]?) -> Result<AVURLAsset, ResourceLoadingError> {
         urlAssetFuncCheck.call((mediaURL, data))
         return urlAssetStub
     }

--- a/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/SchemeHandlerTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/SchemeHandlerTests.swift
@@ -60,7 +60,7 @@ final class SchemeHandlerTests: XCTestCase {
         let expectedResult: Result<AVURLAsset, ResourceLoadingError> = .failure(.urlScheme)
         
         // WHEN
-        let finalResult = schemeHandler.urlAsset(with: url, data: .init(), urlAssetCookies: nil)
+        let finalResult = schemeHandler.urlAsset(with: url, data: .init(), headers: nil)
         
         // THEN
         XCTAssertEqual(expectedResult, finalResult)
@@ -73,7 +73,7 @@ final class SchemeHandlerTests: XCTestCase {
         let givenData = Data.mock(string: "#WRONG-E-X-T-I-N-F")
         
         // WHEN
-        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData, urlAssetCookies: nil).get().url.scheme
+        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData, headers: nil).get().url.scheme
         
         // THEN
         XCTAssertEqual(expectedScheme, resultScheme)
@@ -86,7 +86,7 @@ final class SchemeHandlerTests: XCTestCase {
         let givenData = Data.mock(string: "#EXTINF")
         
         // WHEN
-        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData, urlAssetCookies: nil).get().url.scheme
+        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData, headers: nil).get().url.scheme
         
         // THEN
         XCTAssertEqual(expectedScheme, resultScheme)

--- a/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/SchemeHandlerTests.swift
+++ b/VidLoader/VidLoaderTests/Tests/Classes/ResourceLoader/SchemeHandlerTests.swift
@@ -60,7 +60,7 @@ final class SchemeHandlerTests: XCTestCase {
         let expectedResult: Result<AVURLAsset, ResourceLoadingError> = .failure(.urlScheme)
         
         // WHEN
-        let finalResult = schemeHandler.urlAsset(with: url, data: .init())
+        let finalResult = schemeHandler.urlAsset(with: url, data: .init(), urlAssetCookies: nil)
         
         // THEN
         XCTAssertEqual(expectedResult, finalResult)
@@ -73,7 +73,7 @@ final class SchemeHandlerTests: XCTestCase {
         let givenData = Data.mock(string: "#WRONG-E-X-T-I-N-F")
         
         // WHEN
-        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData).get().url.scheme
+        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData, urlAssetCookies: nil).get().url.scheme
         
         // THEN
         XCTAssertEqual(expectedScheme, resultScheme)
@@ -86,7 +86,7 @@ final class SchemeHandlerTests: XCTestCase {
         let givenData = Data.mock(string: "#EXTINF")
         
         // WHEN
-        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData).get().url.scheme
+        let resultScheme = try? schemeHandler.urlAsset(with: url, data: givenData, urlAssetCookies: nil).get().url.scheme
         
         // THEN
         XCTAssertEqual(expectedScheme, resultScheme)


### PR DESCRIPTION
I am reopening this pull request to implement the improvements suggested by the repository owner following its previous closure #38. This update aims to enable the download of signed videos on AWS CloudFront using essential parameters: CloudFront-Key-Pair-Id, CloudFront-Policy, and CloudFront-Signature.

The proposed enhancements are based on AWS's official documentation on accessing private and signed content, available [here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-cookies.html).

Looking forward to feedback and eager to contribute to advancing this implementation.

Thank you.